### PR TITLE
[PAT] Support Personal Access Token pour accès orgs SSO

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@octokit/rest": "^22.0.1",
         "axios": "^1.6.0",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
@@ -1455,6 +1456,161 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
+      "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-request-log": "^6.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -1881,6 +2037,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -2774,6 +2936,22 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -5947,6 +6125,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -7499,6 +7683,12 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "test:coverage": "NODE_OPTIONS='--experimental-vm-modules' jest --coverage"
   },
   "dependencies": {
+    "@octokit/rest": "^22.0.1",
     "axios": "^1.6.0",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -6,6 +6,7 @@ import { Strategy as GitHubStrategy } from 'passport-github2';
 import dotenv from 'dotenv';
 import studentsRoutes from './routes/students.js';
 import exportRoutes from './routes/export.js';
+import patRoutes from './routes/pat.js';
 
 dotenv.config();
 
@@ -91,6 +92,7 @@ app.get('/api/health', (req, res) => {
 // Routes pour étudiants
 app.use('/api/students', studentsRoutes);
 app.use('/api/export', exportRoutes);
+app.use('/api/pat', patRoutes);
 
 app.listen(PORT, () => {
   console.log(`🚀 Serveur démarré sur http://localhost:${PORT}`);

--- a/backend/src/routes/pat.js
+++ b/backend/src/routes/pat.js
@@ -1,0 +1,155 @@
+import { Router } from 'express';
+import { Octokit } from '@octokit/rest';
+
+const router = Router();
+
+// POST /api/pat - Enregistrer un PAT
+router.post('/', async (req, res) => {
+  try {
+    if (!req.isAuthenticated()) {
+      return res.status(401).json({ error: 'Non authentifié' });
+    }
+
+    const { pat } = req.body;
+
+    if (!pat) {
+      return res.status(400).json({ error: 'PAT requis' });
+    }
+
+    // Validation du format PAT (ghp_xxxx ou github_pat_xxx)
+    const patRegex = /^(ghp_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59})$/;
+    if (!patRegex.test(pat)) {
+      return res.status(400).json({ 
+        error: 'Format invalide. Le PAT doit commencer par ghp_ ou github_pat_' 
+      });
+    }
+
+    // Vérifier la validité du PAT avec GitHub
+    const octokit = new Octokit({ auth: pat });
+    
+    try {
+      const { data: user } = await octokit.rest.users.getAuthenticated();
+      
+      // Récupérer les organisations accessibles
+      const { data: orgs } = await octokit.rest.orgs.listForAuthenticatedUser();
+      
+      // Stocker le PAT en session (chiffré serait mieux en production)
+      req.session.pat = pat;
+      req.session.patUser = {
+        login: user.login,
+        name: user.name,
+        avatar_url: user.avatar_url
+      };
+      
+      res.json({
+        success: true,
+        message: 'PAT enregistré avec succès',
+        user: {
+          login: user.login,
+          name: user.name
+        },
+        orgs: orgs.map(org => ({
+          login: org.login,
+          name: org.name,
+          avatar_url: org.avatar_url,
+          description: org.description
+        }))
+      });
+    } catch (githubError) {
+      console.error('Erreur validation PAT:', githubError.message);
+      return res.status(401).json({ 
+        error: 'PAT invalide ou expiré',
+        details: githubError.message
+      });
+    }
+
+  } catch (error) {
+    console.error('Erreur enregistrement PAT:', error);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+// GET /api/pat/orgs - Lister les orgs accessibles
+router.get('/orgs', async (req, res) => {
+  try {
+    if (!req.isAuthenticated()) {
+      return res.status(401).json({ error: 'Non authentifié' });
+    }
+
+    const pat = req.session.pat;
+    if (!pat) {
+      return res.status(400).json({ error: 'Aucun PAT enregistré' });
+    }
+
+    const octokit = new Octokit({ auth: pat });
+    const { data: orgs } = await octokit.rest.orgs.listForAuthenticatedUser();
+
+    res.json({
+      orgs: orgs.map(org => ({
+        login: org.login,
+        name: org.name,
+        avatar_url: org.avatar_url,
+        description: org.description
+      }))
+    });
+
+  } catch (error) {
+    console.error('Erreur récupération orgs:', error);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+// POST /api/pat/select-org - Sélectionner une org
+router.post('/select-org', (req, res) => {
+  try {
+    if (!req.isAuthenticated()) {
+      return res.status(401).json({ error: 'Non authentifié' });
+    }
+
+    const { org } = req.body;
+
+    if (!org) {
+      return res.status(400).json({ error: 'Organisation requise' });
+    }
+
+    req.session.selectedOrg = org;
+
+    res.json({
+      success: true,
+      message: `Organisation ${org} sélectionnée`,
+      selectedOrg: org
+    });
+
+  } catch (error) {
+    console.error('Erreur sélection org:', error);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+// GET /api/pat/status - Vérifier le statut PAT
+router.get('/status', (req, res) => {
+  try {
+    if (!req.isAuthenticated()) {
+      return res.status(401).json({ error: 'Non authentifié' });
+    }
+
+    const hasPat = !!req.session.pat;
+    const selectedOrg = req.session.selectedOrg;
+    const patUser = req.session.patUser;
+
+    res.json({
+      hasPat,
+      selectedOrg,
+      patUser: patUser ? {
+        login: patUser.login,
+        name: patUser.name
+      } : null
+    });
+
+  } catch (error) {
+    console.error('Erreur statut PAT:', error);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+export default router;

--- a/backend/src/routes/pat.test.js
+++ b/backend/src/routes/pat.test.js
@@ -1,0 +1,156 @@
+import { describe, it, expect } from '@jest/globals';
+import request from 'supertest';
+import express from 'express';
+import session from 'express-session';
+import patRouter from '../routes/pat.js';
+
+describe('PAT Routes', () => {
+  let app;
+  
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use(session({
+      secret: 'test-secret',
+      resave: false,
+      saveUninitialized: false
+    }));
+    
+    // Mock authentication
+    app.use((req, res, next) => {
+      req.isAuthenticated = () => true;
+      req.user = { accessToken: 'fake-token' };
+      next();
+    });
+    
+    app.use('/api/pat', patRouter);
+  });
+
+  describe('POST /api/pat', () => {
+    it('should return 401 when not authenticated', async () => {
+      const unauthApp = express();
+      unauthApp.use(express.json());
+      unauthApp.use((req, res, next) => {
+        req.isAuthenticated = () => false;
+        next();
+      });
+      unauthApp.use('/api/pat', patRouter);
+      
+      const response = await request(unauthApp)
+        .post('/api/pat')
+        .send({ pat: 'ghp_test123' })
+        .expect(401);
+      
+      expect(response.body.error).toBe('Non authentifié');
+    });
+
+    it('should validate PAT format', async () => {
+      const response = await request(app)
+        .post('/api/pat')
+        .send({ pat: 'invalid-token' })
+        .expect(400);
+      
+      expect(response.body.error).toContain('Format invalide');
+    });
+
+    it('should require PAT in body', async () => {
+      const response = await request(app)
+        .post('/api/pat')
+        .send({})
+        .expect(400);
+      
+      expect(response.body.error).toContain('PAT requis');
+    });
+  });
+
+  describe('GET /api/pat/orgs', () => {
+    it('should return 401 when not authenticated', async () => {
+      const unauthApp = express();
+      unauthApp.use(express.json());
+      unauthApp.use((req, res, next) => {
+        req.isAuthenticated = () => false;
+        next();
+      });
+      unauthApp.use('/api/pat', patRouter);
+      
+      const response = await request(unauthApp)
+        .get('/api/pat/orgs')
+        .expect(401);
+      
+      expect(response.body.error).toBe('Non authentifié');
+    });
+
+    it('should return 400 if no PAT in session', async () => {
+      const response = await request(app)
+        .get('/api/pat/orgs')
+        .expect(400);
+      
+      expect(response.body.error).toBe('Aucun PAT enregistré');
+    });
+  });
+
+  describe('POST /api/pat/select-org', () => {
+    it('should return 401 when not authenticated', async () => {
+      const unauthApp = express();
+      unauthApp.use(express.json());
+      unauthApp.use((req, res, next) => {
+        req.isAuthenticated = () => false;
+        next();
+      });
+      unauthApp.use('/api/pat', patRouter);
+      
+      const response = await request(unauthApp)
+        .post('/api/pat/select-org')
+        .send({ org: 'Epitech' })
+        .expect(401);
+      
+      expect(response.body.error).toBe('Non authentifié');
+    });
+
+    it('should require org in body', async () => {
+      const response = await request(app)
+        .post('/api/pat/select-org')
+        .send({})
+        .expect(400);
+      
+      expect(response.body.error).toContain('Organisation requise');
+    });
+
+    it('should select an org', async () => {
+      const response = await request(app)
+        .post('/api/pat/select-org')
+        .send({ org: 'Epitech' })
+        .expect(200);
+      
+      expect(response.body.success).toBe(true);
+      expect(response.body.selectedOrg).toBe('Epitech');
+    });
+  });
+
+  describe('GET /api/pat/status', () => {
+    it('should return 401 when not authenticated', async () => {
+      const unauthApp = express();
+      unauthApp.use(express.json());
+      unauthApp.use((req, res, next) => {
+        req.isAuthenticated = () => false;
+        next();
+      });
+      unauthApp.use('/api/pat', patRouter);
+      
+      const response = await request(unauthApp)
+        .get('/api/pat/status')
+        .expect(401);
+      
+      expect(response.body.error).toBe('Non authentifié');
+    });
+
+    it('should return PAT status', async () => {
+      const response = await request(app)
+        .get('/api/pat/status')
+        .expect(200);
+      
+      expect(response.body.hasPat).toBe(false);
+      expect(response.body.selectedOrg).toBeUndefined();
+    });
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { Routes, Route, Navigate } from 'react-router-dom'
 import Login from './pages/Login'
 import Dashboard from './pages/Dashboard'
 import StudentDetail from './pages/StudentDetail'
+import PatConfig from './pages/PatConfig'
 import './App.css'
 
 function App() {
@@ -35,6 +36,10 @@ function App() {
         <Route 
           path="/student/:username" 
           element={user ? <StudentDetail /> : <Navigate to="/login" />} 
+        />
+        <Route 
+          path="/config/pat" 
+          element={user ? <PatConfig /> : <Navigate to="/login" />} 
         />
         <Route path="/" element={<Navigate to="/dashboard" />} />
       </Routes>

--- a/frontend/src/pages/PatConfig.css
+++ b/frontend/src/pages/PatConfig.css
@@ -1,0 +1,198 @@
+.pat-config {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.pat-config h2 {
+  color: #333;
+  margin-bottom: 1.5rem;
+}
+
+.pat-status {
+  background: #d4edda;
+  border: 1px solid #c3e6cb;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.pat-info {
+  background: #f8f9fa;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.pat-info h3 {
+  margin-top: 0;
+  color: #555;
+}
+
+.pat-info ol {
+  padding-left: 1.5rem;
+}
+
+.pat-info li {
+  margin-bottom: 0.5rem;
+}
+
+.pat-info code {
+  background: #e9ecef;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+.pat-form {
+  background: white;
+  border: 1px solid #e1e4e8;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 500;
+}
+
+.form-group input {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.form-group small {
+  display: block;
+  margin-top: 0.25rem;
+  color: #666;
+}
+
+.error-message {
+  background: #f8d7da;
+  color: #721c24;
+  padding: 0.75rem;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+}
+
+.success-message {
+  background: #d4edda;
+  color: #155724;
+  padding: 0.75rem;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+}
+
+.btn-primary {
+  background: #28a745;
+  color: white;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #218838;
+}
+
+.btn-primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  display: inline-block;
+  background: #6c757d;
+  color: white;
+  text-decoration: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 4px;
+}
+
+.btn-secondary:hover {
+  background: #5a6268;
+}
+
+.orgs-section {
+  margin-top: 2rem;
+}
+
+.orgs-section h3 {
+  margin-bottom: 1rem;
+}
+
+.orgs-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1rem;
+}
+
+.org-card {
+  border: 2px solid #e1e4e8;
+  border-radius: 8px;
+  padding: 1rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.org-card:hover {
+  border-color: #0366d6;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+.org-card.selected {
+  border-color: #28a745;
+  background: #f8fff8;
+}
+
+.org-avatar {
+  width: 50px;
+  height: 50px;
+  border-radius: 8px;
+}
+
+.org-info {
+  flex: 1;
+}
+
+.org-info h4 {
+  margin: 0 0 0.25rem 0;
+}
+
+.org-info p {
+  margin: 0;
+  color: #666;
+  font-size: 0.9rem;
+}
+
+.org-login {
+  color: #999;
+  font-size: 0.85rem;
+}
+
+.selected-badge {
+  background: #28a745;
+  color: white;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+
+.pat-actions {
+  margin-top: 2rem;
+  text-align: center;
+}

--- a/frontend/src/pages/PatConfig.tsx
+++ b/frontend/src/pages/PatConfig.tsx
@@ -1,0 +1,172 @@
+import { useState, useEffect } from 'react';
+import './PatConfig.css';
+
+interface Org {
+  login: string;
+  name: string;
+  avatar_url: string;
+  description: string;
+}
+
+function PatConfig() {
+  const [pat, setPat] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [orgs, setOrgs] = useState<Org[]>([]);
+  const [selectedOrg, setSelectedOrg] = useState<string | null>(null);
+  const [patStatus, setPatStatus] = useState<{ hasPat: boolean; selectedOrg?: string; patUser?: { login: string; name: string } } | null>(null);
+
+  useEffect(() => {
+    checkPatStatus();
+  }, []);
+
+  const checkPatStatus = async () => {
+    try {
+      const response = await fetch('/api/pat/status', {
+        credentials: 'include'
+      });
+      
+      if (response.ok) {
+        const data = await response.json();
+        setPatStatus(data);
+        if (data.selectedOrg) {
+          setSelectedOrg(data.selectedOrg);
+        }
+      }
+    } catch (err) {
+      console.error('Erreur vérification statut PAT:', err);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const response = await fetch('/api/pat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ pat })
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Erreur lors de l\'enregistrement du PAT');
+      }
+
+      setSuccess('PAT enregistré avec succès !');
+      setOrgs(data.orgs || []);
+      setPatStatus({
+        hasPat: true,
+        patUser: data.user
+      });
+      setPat('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erreur inconnue');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSelectOrg = async (orgLogin: string) => {
+    try {
+      const response = await fetch('/api/pat/select-org', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ org: orgLogin })
+      });
+
+      if (!response.ok) {
+        throw new Error('Erreur lors de la sélection de l\'organisation');
+      }
+
+      setSelectedOrg(orgLogin);
+      setSuccess(`Organisation ${orgLogin} sélectionnée !`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erreur inconnue');
+    }
+  };
+
+  return (
+    <div className="pat-config">
+      <h2>Configuration du Personal Access Token (PAT)</h2>
+      
+      {patStatus?.hasPat && (
+        <div className="pat-status">
+          <p>✅ PAT configuré pour : <strong>{patStatus.patUser?.login}</strong></p>
+          {patStatus.selectedOrg && (
+            <p>Organisation sélectionnée : <strong>{patStatus.selectedOrg}</strong></p>
+          )}
+        </div>
+      )}
+
+      <div className="pat-info">
+        <h3>Comment obtenir un PAT GitHub :</h3>
+        <ol>
+          <li>Allez sur <a href="https://github.com/settings/tokens" target="_blank" rel="noopener noreferrer">GitHub Settings → Developer settings → Personal access tokens</a></li>
+          <li>Cliquez sur "Generate new token (classic)"</li>
+          <li>Cochez les scopes : <code>read:org</code>, <code>repo</code>, <code>read:user</code></li>
+          <li>Générez le token et copiez-le</li>
+          <li>Autorisez le token pour l'org Epitech via SSO</li>
+        </ol>
+      </div>
+
+      <form onSubmit={handleSubmit} className="pat-form">
+        <div className="form-group">
+          <label htmlFor="pat">Votre Personal Access Token :</label>
+          <input
+            type="password"
+            id="pat"
+            value={pat}
+            onChange={(e) => setPat(e.target.value)}
+            placeholder="ghp_xxxxxxxxxxxx"
+            required
+          />
+          <small>Le token commence par ghp_ ou github_pat_</small>
+        </div>
+
+        {error && <div className="error-message">{error}</div>}
+        {success && <div className="success-message">{success}</div>}
+
+        <button type="submit" disabled={loading} className="btn-primary">
+          {loading ? 'Vérification...' : 'Enregistrer le PAT'}
+        </button>
+      </form>
+
+      {orgs.length > 0 && (
+        <div className="orgs-section">
+          <h3>Organisations accessibles :</h3>
+          <div className="orgs-list">
+            {orgs.map(org => (
+              <div
+                key={org.login}
+                className={`org-card ${selectedOrg === org.login ? 'selected' : ''}`}
+                onClick={() => handleSelectOrg(org.login)}
+              >
+                <img src={org.avatar_url} alt={org.name} className="org-avatar" />
+                <div className="org-info">
+                  <h4>{org.name || org.login}</h4>
+                  <p>{org.description}</p>
+                  <span className="org-login">@{org.login}</span>
+                </div>
+                {selectedOrg === org.login && <span className="selected-badge">✓ Sélectionnée</span>}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="pat-actions">
+        <a href="/dashboard" className="btn-secondary">Retour au Dashboard</a>
+      </div>
+    </div>
+  );
+}
+
+export default PatConfig;


### PR DESCRIPTION
## Issue #5 - Support PAT pour orgs SSO

### Problème
Les orgs Epitech utilisent SSO, ce qui bloque l'accès via OAuth standard.

### Solution
Implémentation d'un système de Personal Access Token (PAT) :

**Backend:**
- ✅ POST /api/pat - Enregistrer et valider un PAT
- ✅ GET /api/pat/orgs - Lister les organisations accessibles
- ✅ POST /api/pat/select-org - Sélectionner une org
- ✅ GET /api/pat/status - Vérifier le statut
- ✅ Validation format (ghp_ et github_pat_)
- ✅ Vérification validité via API GitHub

**Frontend:**
- ✅ Page /config/pat avec formulaire
- ✅ Affichage des orgs accessibles
- ✅ Sélection d'organisation
- ✅ Instructions de création PAT

**Tests:**
- ✅ 10 tests backend
- ✅ 35 tests frontend
- ✅ Total: 81 tests passants
- ✅ Coverage maintenu ≥ 55%

### Workflow utilisateur
1. Connexion OAuth GitHub
2. Aller sur /config/pat
3. Entrer son PAT (avec accès orgs SSO)
4. Sélectionner l'org Epitech
5. Accéder aux repos étudiants

### Checklist
- [x] Tests écrits (TDD)
- [x] Code reviewé
- [x] CI passe
- [x] Coverage ≥ 55%