### PR TITLE
[US6-US7-PAT] Webhooks + Vue projets + PAT auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ Thumbs.db
 npm-debug.log*
 
 # Testing
-*/coverage/
+*/coverage/backend/data/

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@octokit/rest": "^22.0.1",
         "axios": "^1.6.0",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
@@ -1455,6 +1456,161 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
+      "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-request-log": "^6.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -1881,6 +2037,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -2774,6 +2936,22 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -5947,6 +6125,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -7499,6 +7683,12 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "test:coverage": "NODE_OPTIONS='--experimental-vm-modules' jest --coverage"
   },
   "dependencies": {
+    "@octokit/rest": "^22.0.1",
     "axios": "^1.6.0",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -6,6 +6,7 @@ import { Strategy as GitHubStrategy } from 'passport-github2';
 import dotenv from 'dotenv';
 import studentsRoutes from './routes/students.js';
 import exportRoutes from './routes/export.js';
+import patRoutes from './routes/pat.js';
 
 dotenv.config();
 
@@ -91,6 +92,7 @@ app.get('/api/health', (req, res) => {
 // Routes pour étudiants
 app.use('/api/students', studentsRoutes);
 app.use('/api/export', exportRoutes);
+app.use('/api/pat', patRoutes);
 
 app.listen(PORT, () => {
   console.log(`🚀 Serveur démarré sur http://localhost:${PORT}`);

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -7,6 +7,8 @@ import dotenv from 'dotenv';
 import studentsRoutes from './routes/students.js';
 import exportRoutes from './routes/export.js';
 import patRoutes from './routes/pat.js';
+import webhookRoutes from './routes/webhook.js';
+import projectsRoutes from './routes/projects.js';
 
 dotenv.config();
 
@@ -93,6 +95,8 @@ app.get('/api/health', (req, res) => {
 app.use('/api/students', studentsRoutes);
 app.use('/api/export', exportRoutes);
 app.use('/api/pat', patRoutes);
+app.use('/api/webhook', webhookRoutes);
+app.use('/api/projects', projectsRoutes);
 
 app.listen(PORT, () => {
   console.log(`🚀 Serveur démarré sur http://localhost:${PORT}`);

--- a/backend/src/routes/pat.js
+++ b/backend/src/routes/pat.js
@@ -1,0 +1,155 @@
+import { Router } from 'express';
+import { Octokit } from '@octokit/rest';
+
+const router = Router();
+
+// POST /api/pat - Enregistrer un PAT
+router.post('/', async (req, res) => {
+  try {
+    if (!req.isAuthenticated()) {
+      return res.status(401).json({ error: 'Non authentifié' });
+    }
+
+    const { pat } = req.body;
+
+    if (!pat) {
+      return res.status(400).json({ error: 'PAT requis' });
+    }
+
+    // Validation du format PAT (ghp_xxxx ou github_pat_xxx)
+    const patRegex = /^(ghp_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59})$/;
+    if (!patRegex.test(pat)) {
+      return res.status(400).json({ 
+        error: 'Format invalide. Le PAT doit commencer par ghp_ ou github_pat_' 
+      });
+    }
+
+    // Vérifier la validité du PAT avec GitHub
+    const octokit = new Octokit({ auth: pat });
+    
+    try {
+      const { data: user } = await octokit.rest.users.getAuthenticated();
+      
+      // Récupérer les organisations accessibles
+      const { data: orgs } = await octokit.rest.orgs.listForAuthenticatedUser();
+      
+      // Stocker le PAT en session (chiffré serait mieux en production)
+      req.session.pat = pat;
+      req.session.patUser = {
+        login: user.login,
+        name: user.name,
+        avatar_url: user.avatar_url
+      };
+      
+      res.json({
+        success: true,
+        message: 'PAT enregistré avec succès',
+        user: {
+          login: user.login,
+          name: user.name
+        },
+        orgs: orgs.map(org => ({
+          login: org.login,
+          name: org.name,
+          avatar_url: org.avatar_url,
+          description: org.description
+        }))
+      });
+    } catch (githubError) {
+      console.error('Erreur validation PAT:', githubError.message);
+      return res.status(401).json({ 
+        error: 'PAT invalide ou expiré',
+        details: githubError.message
+      });
+    }
+
+  } catch (error) {
+    console.error('Erreur enregistrement PAT:', error);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+// GET /api/pat/orgs - Lister les orgs accessibles
+router.get('/orgs', async (req, res) => {
+  try {
+    if (!req.isAuthenticated()) {
+      return res.status(401).json({ error: 'Non authentifié' });
+    }
+
+    const pat = req.session.pat;
+    if (!pat) {
+      return res.status(400).json({ error: 'Aucun PAT enregistré' });
+    }
+
+    const octokit = new Octokit({ auth: pat });
+    const { data: orgs } = await octokit.rest.orgs.listForAuthenticatedUser();
+
+    res.json({
+      orgs: orgs.map(org => ({
+        login: org.login,
+        name: org.name,
+        avatar_url: org.avatar_url,
+        description: org.description
+      }))
+    });
+
+  } catch (error) {
+    console.error('Erreur récupération orgs:', error);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+// POST /api/pat/select-org - Sélectionner une org
+router.post('/select-org', (req, res) => {
+  try {
+    if (!req.isAuthenticated()) {
+      return res.status(401).json({ error: 'Non authentifié' });
+    }
+
+    const { org } = req.body;
+
+    if (!org) {
+      return res.status(400).json({ error: 'Organisation requise' });
+    }
+
+    req.session.selectedOrg = org;
+
+    res.json({
+      success: true,
+      message: `Organisation ${org} sélectionnée`,
+      selectedOrg: org
+    });
+
+  } catch (error) {
+    console.error('Erreur sélection org:', error);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+// GET /api/pat/status - Vérifier le statut PAT
+router.get('/status', (req, res) => {
+  try {
+    if (!req.isAuthenticated()) {
+      return res.status(401).json({ error: 'Non authentifié' });
+    }
+
+    const hasPat = !!req.session.pat;
+    const selectedOrg = req.session.selectedOrg;
+    const patUser = req.session.patUser;
+
+    res.json({
+      hasPat,
+      selectedOrg,
+      patUser: patUser ? {
+        login: patUser.login,
+        name: patUser.name
+      } : null
+    });
+
+  } catch (error) {
+    console.error('Erreur statut PAT:', error);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+export default router;

--- a/backend/src/routes/pat.js
+++ b/backend/src/routes/pat.js
@@ -6,11 +6,14 @@ const router = Router();
 // POST /api/pat - Enregistrer un PAT
 router.post('/', async (req, res) => {
   try {
+    console.log('PAT: Requête reçue, authentification:', req.isAuthenticated());
+    
     if (!req.isAuthenticated()) {
       return res.status(401).json({ error: 'Non authentifié' });
     }
 
     const { pat } = req.body;
+    console.log('PAT: Token reçu (début):', pat ? pat.substring(0, 10) + '...' : 'undefined');
 
     if (!pat) {
       return res.status(400).json({ error: 'PAT requis' });
@@ -19,6 +22,7 @@ router.post('/', async (req, res) => {
     // Validation du format PAT (ghp_xxxx ou github_pat_xxx)
     const patRegex = /^(ghp_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59})$/;
     if (!patRegex.test(pat)) {
+      console.log('PAT: Format invalide');
       return res.status(400).json({ 
         error: 'Format invalide. Le PAT doit commencer par ghp_ ou github_pat_' 
       });
@@ -28,10 +32,13 @@ router.post('/', async (req, res) => {
     const octokit = new Octokit({ auth: pat });
     
     try {
+      console.log('PAT: Vérification avec GitHub...');
       const { data: user } = await octokit.rest.users.getAuthenticated();
+      console.log('PAT: Utilisateur authentifié:', user.login);
       
       // Récupérer les organisations accessibles
       const { data: orgs } = await octokit.rest.orgs.listForAuthenticatedUser();
+      console.log('PAT: Orgs récupérées:', orgs.length);
       
       // Stocker le PAT en session (chiffré serait mieux en production)
       req.session.pat = pat;
@@ -40,6 +47,15 @@ router.post('/', async (req, res) => {
         name: user.name,
         avatar_url: user.avatar_url
       };
+      
+      // Sauvegarder explicitement la session
+      req.session.save((err) => {
+        if (err) {
+          console.error('PAT: Erreur sauvegarde session:', err);
+          return res.status(500).json({ error: 'Erreur sauvegarde session' });
+        }
+        console.log('PAT: Session sauvegardée avec succès');
+      });
       
       res.json({
         success: true,

--- a/backend/src/routes/pat.js
+++ b/backend/src/routes/pat.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { Octokit } from '@octokit/rest';
+import { saveUserPat, getUserPat, removeUserPat } from '../services/patStorage.js';
 
 const router = Router();
 
@@ -49,6 +50,28 @@ router.post('/', async (req, res) => {
       };
       
       // Sauvegarder explicitement la session
+      req.session.pat = pat;
+      req.session.patUser = {
+        login: user.login,
+        name: user.name,
+        avatar_url: user.avatar_url
+      };
+      
+      // Sauvegarder dans le stockage persistant
+      saveUserPat(req.user.id, {
+        pat,
+        user: {
+          login: user.login,
+          name: user.name,
+          avatar_url: user.avatar_url
+        },
+        orgs: orgs.map(org => ({
+          login: org.login,
+          name: org.name,
+          avatar_url: org.avatar_url
+        }))
+      });
+      
       req.session.save((err) => {
         if (err) {
           console.error('PAT: Erreur sauvegarde session:', err);
@@ -92,7 +115,18 @@ router.get('/orgs', async (req, res) => {
       return res.status(401).json({ error: 'Non authentifié' });
     }
 
-    const pat = req.session.pat;
+    let pat = req.session.pat;
+    
+    // Si pas en session, essayer depuis le stockage persistant
+    if (!pat && req.user.id) {
+      const storedPat = getUserPat(req.user.id);
+      if (storedPat) {
+        pat = storedPat.pat;
+        req.session.pat = pat;
+        req.session.patUser = storedPat.user;
+      }
+    }
+    
     if (!pat) {
       return res.status(400).json({ error: 'Aucun PAT enregistré' });
     }
@@ -149,9 +183,22 @@ router.get('/status', (req, res) => {
       return res.status(401).json({ error: 'Non authentifié' });
     }
 
-    const hasPat = !!req.session.pat;
-    const selectedOrg = req.session.selectedOrg;
-    const patUser = req.session.patUser;
+    // Essayer de récupérer depuis la session d'abord
+    let hasPat = !!req.session.pat;
+    let selectedOrg = req.session.selectedOrg;
+    let patUser = req.session.patUser;
+
+    // Si pas en session, essayer depuis le stockage persistant
+    if (!hasPat && req.user.id) {
+      const storedPat = getUserPat(req.user.id);
+      if (storedPat) {
+        hasPat = true;
+        patUser = storedPat.user;
+        // Restaurer dans la session
+        req.session.pat = storedPat.pat;
+        req.session.patUser = storedPat.user;
+      }
+    }
 
     res.json({
       hasPat,

--- a/backend/src/routes/pat.test.js
+++ b/backend/src/routes/pat.test.js
@@ -1,0 +1,156 @@
+import { describe, it, expect } from '@jest/globals';
+import request from 'supertest';
+import express from 'express';
+import session from 'express-session';
+import patRouter from '../routes/pat.js';
+
+describe('PAT Routes', () => {
+  let app;
+  
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use(session({
+      secret: 'test-secret',
+      resave: false,
+      saveUninitialized: false
+    }));
+    
+    // Mock authentication
+    app.use((req, res, next) => {
+      req.isAuthenticated = () => true;
+      req.user = { accessToken: 'fake-token' };
+      next();
+    });
+    
+    app.use('/api/pat', patRouter);
+  });
+
+  describe('POST /api/pat', () => {
+    it('should return 401 when not authenticated', async () => {
+      const unauthApp = express();
+      unauthApp.use(express.json());
+      unauthApp.use((req, res, next) => {
+        req.isAuthenticated = () => false;
+        next();
+      });
+      unauthApp.use('/api/pat', patRouter);
+      
+      const response = await request(unauthApp)
+        .post('/api/pat')
+        .send({ pat: 'ghp_test123' })
+        .expect(401);
+      
+      expect(response.body.error).toBe('Non authentifié');
+    });
+
+    it('should validate PAT format', async () => {
+      const response = await request(app)
+        .post('/api/pat')
+        .send({ pat: 'invalid-token' })
+        .expect(400);
+      
+      expect(response.body.error).toContain('Format invalide');
+    });
+
+    it('should require PAT in body', async () => {
+      const response = await request(app)
+        .post('/api/pat')
+        .send({})
+        .expect(400);
+      
+      expect(response.body.error).toContain('PAT requis');
+    });
+  });
+
+  describe('GET /api/pat/orgs', () => {
+    it('should return 401 when not authenticated', async () => {
+      const unauthApp = express();
+      unauthApp.use(express.json());
+      unauthApp.use((req, res, next) => {
+        req.isAuthenticated = () => false;
+        next();
+      });
+      unauthApp.use('/api/pat', patRouter);
+      
+      const response = await request(unauthApp)
+        .get('/api/pat/orgs')
+        .expect(401);
+      
+      expect(response.body.error).toBe('Non authentifié');
+    });
+
+    it('should return 400 if no PAT in session', async () => {
+      const response = await request(app)
+        .get('/api/pat/orgs')
+        .expect(400);
+      
+      expect(response.body.error).toBe('Aucun PAT enregistré');
+    });
+  });
+
+  describe('POST /api/pat/select-org', () => {
+    it('should return 401 when not authenticated', async () => {
+      const unauthApp = express();
+      unauthApp.use(express.json());
+      unauthApp.use((req, res, next) => {
+        req.isAuthenticated = () => false;
+        next();
+      });
+      unauthApp.use('/api/pat', patRouter);
+      
+      const response = await request(unauthApp)
+        .post('/api/pat/select-org')
+        .send({ org: 'Epitech' })
+        .expect(401);
+      
+      expect(response.body.error).toBe('Non authentifié');
+    });
+
+    it('should require org in body', async () => {
+      const response = await request(app)
+        .post('/api/pat/select-org')
+        .send({})
+        .expect(400);
+      
+      expect(response.body.error).toContain('Organisation requise');
+    });
+
+    it('should select an org', async () => {
+      const response = await request(app)
+        .post('/api/pat/select-org')
+        .send({ org: 'Epitech' })
+        .expect(200);
+      
+      expect(response.body.success).toBe(true);
+      expect(response.body.selectedOrg).toBe('Epitech');
+    });
+  });
+
+  describe('GET /api/pat/status', () => {
+    it('should return 401 when not authenticated', async () => {
+      const unauthApp = express();
+      unauthApp.use(express.json());
+      unauthApp.use((req, res, next) => {
+        req.isAuthenticated = () => false;
+        next();
+      });
+      unauthApp.use('/api/pat', patRouter);
+      
+      const response = await request(unauthApp)
+        .get('/api/pat/status')
+        .expect(401);
+      
+      expect(response.body.error).toBe('Non authentifié');
+    });
+
+    it('should return PAT status', async () => {
+      const response = await request(app)
+        .get('/api/pat/status')
+        .expect(200);
+      
+      expect(response.body.hasPat).toBe(false);
+      expect(response.body.selectedOrg).toBeUndefined();
+    });
+  });
+});

--- a/backend/src/routes/projects.js
+++ b/backend/src/routes/projects.js
@@ -1,0 +1,94 @@
+import express from 'express';
+import GitHubService from '../services/github.js';
+
+const router = express.Router();
+
+/**
+ * GET /api/projects
+ * Récupère la liste des projets/repos avec les étudiants qui contribuent
+ */
+router.get('/', async (req, res) => {
+  try {
+    if (!req.isAuthenticated || !req.isAuthenticated()) {
+      return res.status(401).json({ error: 'Non authentifié' });
+    }
+
+    // Utiliser le PAT s'il est configuré, sinon utiliser le token OAuth
+    const accessToken = req.session.pat || req.user.accessToken;
+    const github = new GitHubService(accessToken);
+    
+    const org = req.query.org || req.session.selectedOrg || 'Epitech';
+    
+    // Récupérer tous les repos de l'organisation
+    const repos = await github.getOrgRepos(org);
+    
+    // Pour chaque repo, récupérer les contributeurs
+    const projectsWithContributors = await Promise.all(
+      repos.slice(0, 50).map(async (repo) => {
+        try {
+          // Récupérer les contributeurs
+          const contributors = await github.getRepoContributors(org, repo.name);
+          
+          // Récupérer les commits récents
+          const commits = await github.getRepoCommits(org, repo.name);
+          
+          return {
+            id: repo.id,
+            name: repo.name,
+            description: repo.description,
+            url: repo.html_url,
+            language: repo.language,
+            stars: repo.stargazers_count,
+            forks: repo.forks_count,
+            updatedAt: repo.updated_at,
+            contributors: contributors.map(c => ({
+              username: c.login,
+              avatarUrl: c.avatar_url,
+              contributions: c.contributions
+            })),
+            totalCommits: commits.length,
+            recentCommits: commits.slice(0, 5).map(c => ({
+              message: c.commit.message,
+              author: c.commit.author.name,
+              date: c.commit.author.date,
+              sha: c.sha.substring(0, 7)
+            }))
+          };
+        } catch (error) {
+          console.error(`Erreur pour le repo ${repo.name}:`, error.message);
+          return {
+            id: repo.id,
+            name: repo.name,
+            description: repo.description,
+            url: repo.html_url,
+            language: repo.language,
+            error: true,
+            contributors: [],
+            totalCommits: 0
+          };
+        }
+      })
+    );
+    
+    // Trier par nombre de contributeurs
+    const sortedProjects = projectsWithContributors.sort((a, b) => 
+      b.contributors.length - a.contributors.length
+    );
+    
+    res.json({
+      success: true,
+      count: sortedProjects.length,
+      organization: org,
+      projects: sortedProjects
+    });
+    
+  } catch (error) {
+    console.error('Erreur lors de la récupération des projets:', error);
+    res.status(500).json({
+      error: 'Erreur lors de la récupération des projets',
+      message: error.message
+    });
+  }
+});
+
+export default router;

--- a/backend/src/routes/projects.js
+++ b/backend/src/routes/projects.js
@@ -84,9 +84,19 @@ router.get('/', async (req, res) => {
     
   } catch (error) {
     console.error('Erreur lors de la récupération des projets:', error);
+    
+    // Message d'erreur plus explicite
+    let errorMessage = error.message;
+    if (error.message.includes('Not Found') || error.message.includes('404')) {
+      errorMessage = 'Organisation non trouvée ou accès refusé. Vérifiez votre PAT ou les permissions.';
+    } else if (error.message.includes('Bad credentials') || error.message.includes('401')) {
+      errorMessage = 'Token d\'authentification invalide. Configurez un PAT valide.';
+    }
+    
     res.status(500).json({
       error: 'Erreur lors de la récupération des projets',
-      message: error.message
+      message: errorMessage,
+      requiresPat: !req.session.pat
     });
   }
 });

--- a/backend/src/routes/projects.js
+++ b/backend/src/routes/projects.js
@@ -13,6 +13,11 @@ router.get('/', async (req, res) => {
       return res.status(401).json({ error: 'Non authentifié' });
     }
 
+    // Paramètres de pagination
+    const page = parseInt(req.query.page) || 1;
+    const limit = parseInt(req.query.limit) || 20;
+    const search = req.query.search || '';
+
     // Utiliser le PAT s'il est configuré, sinon utiliser le token OAuth
     const accessToken = req.session.pat || req.user.accessToken;
     const github = new GitHubService(accessToken);
@@ -23,8 +28,8 @@ router.get('/', async (req, res) => {
     const repos = await github.getOrgRepos(org);
     
     // Pour chaque repo, récupérer les contributeurs
-    const projectsWithContributors = await Promise.all(
-      repos.slice(0, 50).map(async (repo) => {
+    let projectsWithContributors = await Promise.all(
+      repos.map(async (repo) => {
         try {
           // Récupérer les contributeurs
           const contributors = await github.getRepoContributors(org, repo.name);
@@ -70,16 +75,36 @@ router.get('/', async (req, res) => {
       })
     );
     
+    // Filtrer par recherche si spécifié
+    if (search.trim()) {
+      const searchLower = search.toLowerCase();
+      projectsWithContributors = projectsWithContributors.filter(project => 
+        project.name.toLowerCase().includes(searchLower) ||
+        (project.description && project.description.toLowerCase().includes(searchLower)) ||
+        (project.language && project.language.toLowerCase().includes(searchLower))
+      );
+    }
+
     // Trier par nombre de contributeurs
     const sortedProjects = projectsWithContributors.sort((a, b) => 
       b.contributors.length - a.contributors.length
     );
     
+    // Pagination
+    const total = sortedProjects.length;
+    const startIndex = (page - 1) * limit;
+    const endIndex = startIndex + limit;
+    const paginatedProjects = sortedProjects.slice(startIndex, endIndex);
+    
     res.json({
       success: true,
-      count: sortedProjects.length,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
       organization: org,
-      projects: sortedProjects
+      search: search || undefined,
+      projects: paginatedProjects
     });
     
   } catch (error) {

--- a/backend/src/routes/projects.test.js
+++ b/backend/src/routes/projects.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from '@jest/globals';
+import request from 'supertest';
+import express from 'express';
+import session from 'express-session';
+import projectsRouter from '../routes/projects.js';
+
+describe('Projects Routes', () => {
+  let app;
+  
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use(session({
+      secret: 'test-secret',
+      resave: false,
+      saveUninitialized: false
+    }));
+    
+    // Mock authentication
+    app.use((req, res, next) => {
+      req.isAuthenticated = () => true;
+      req.user = { accessToken: 'fake-token' };
+      next();
+    });
+    
+    app.use('/api/projects', projectsRouter);
+  });
+
+  describe('GET /api/projects', () => {
+    it('should return 401 when not authenticated', async () => {
+      const unauthApp = express();
+      unauthApp.use(express.json());
+      unauthApp.use((req, res, next) => {
+        req.isAuthenticated = () => false;
+        next();
+      });
+      unauthApp.use('/api/projects', projectsRouter);
+      
+      const response = await request(unauthApp)
+        .get('/api/projects')
+        .expect(401);
+      
+      expect(response.body.error).toBe('Non authentifié');
+    });
+
+    it('should return projects list', async () => {
+      const response = await request(app)
+        .get('/api/projects')
+        .expect(200);
+      
+      expect(response.body.success).toBe(true);
+      expect(response.body.projects).toBeDefined();
+      expect(Array.isArray(response.body.projects)).toBe(true);
+    });
+
+    it('should use org from query parameter', async () => {
+      const response = await request(app)
+        .get('/api/projects?org=TestOrg')
+        .expect(200);
+      
+      expect(response.body.organization).toBe('TestOrg');
+    });
+  });
+});

--- a/backend/src/routes/students.js
+++ b/backend/src/routes/students.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import GitHubService from '../services/github.js';
 import { calculateStudentMetrics } from '../services/metrics.js';
+import { getCacheKey, getFromCache, setCache } from '../services/cache.js';
 
 const router = express.Router();
 
@@ -27,8 +28,13 @@ router.get('/', async (req, res) => {
     // Récupérer l'organisation depuis les paramètres ou utiliser celle sélectionnée
     const org = req.query.org || req.session.selectedOrg || 'Epitech';
     
-    // Récupérer tous les membres de l'organisation
-    const members = await github.getOrgMembers(org, 200);
+    // Vérifier le cache
+    const cacheKey = getCacheKey('students', { org, accessToken: accessToken.slice(0, 10) });
+    let students = getFromCache(cacheKey);
+    
+    if (!students) {
+      // Récupérer tous les membres de l'organisation
+      const members = await github.getOrgMembers(org, 200);
     
     // Récupérer les détails et métriques pour chaque étudiant
     let students = await Promise.all(
@@ -73,23 +79,31 @@ router.get('/', async (req, res) => {
       })
     );
     
-    // Filtrer par recherche si spécifié
+      // Trier par score d'activité (descendant)
+      students = students.sort((a, b) => b.activityScore - a.activityScore);
+      
+      // Sauvegarder dans le cache
+      setCache(cacheKey, students);
+      console.log(`[Cache] Données étudiants mises en cache pour ${org}`);
+    } else {
+      console.log(`[Cache] Données étudiants récupérées depuis le cache pour ${org}`);
+    }
+    
+    // Filtrer par recherche si spécifié (après le cache)
+    let filteredStudents = students;
     if (search.trim()) {
       const searchLower = search.toLowerCase();
-      students = students.filter(student => 
+      filteredStudents = students.filter(student => 
         student.username.toLowerCase().includes(searchLower) ||
         student.displayName.toLowerCase().includes(searchLower)
       );
     }
     
-    // Trier par score d'activité (descendant)
-    const sortedStudents = students.sort((a, b) => b.activityScore - a.activityScore);
-    
     // Pagination
-    const total = sortedStudents.length;
+    const total = filteredStudents.length;
     const startIndex = (page - 1) * limit;
     const endIndex = startIndex + limit;
-    const paginatedStudents = sortedStudents.slice(startIndex, endIndex);
+    const paginatedStudents = filteredStudents.slice(startIndex, endIndex);
     
     res.json({
       success: true,
@@ -99,6 +113,7 @@ router.get('/', async (req, res) => {
       totalPages: Math.ceil(total / limit),
       organization: org,
       search: search || undefined,
+      cached: !!getFromCache(cacheKey),
       students: paginatedStudents
     });
     

--- a/backend/src/routes/students.js
+++ b/backend/src/routes/students.js
@@ -15,21 +15,19 @@ router.get('/', async (req, res) => {
       return res.status(401).json({ error: 'Non authentifié' });
     }
 
-    const { accessToken } = req.user;
+    // Utiliser le PAT s'il est configuré, sinon utiliser le token OAuth
+    const accessToken = req.session.pat || req.user.accessToken;
     const github = new GitHubService(accessToken);
     
-    // Récupérer l'organisation depuis les paramètres ou utiliser une valeur par défaut
-    const org = req.query.org || 'Epitech';
+    // Récupérer l'organisation depuis les paramètres ou utiliser celle sélectionnée
+    const org = req.query.org || req.session.selectedOrg || 'Epitech';
     
-    // Récupérer les membres de l'organisation
-    const members = await github.getOrgMembers(org);
-    
-    // Limiter le nombre d'étudiants pour éviter les rate limits
-    const limitedMembers = members.slice(0, 50);
+    // Récupérer les membres de l'organisation (max 100)
+    const members = await github.getOrgMembers(org, 100);
     
     // Récupérer les détails et métriques pour chaque étudiant
     const students = await Promise.all(
-      limitedMembers.map(async (member) => {
+      members.map(async (member) => {
         try {
           // Récupérer les infos utilisateur
           const user = await github.getUser(member.login);
@@ -100,7 +98,8 @@ router.get('/:username', async (req, res) => {
     }
 
     const { username } = req.params;
-    const { accessToken } = req.user;
+    // Utiliser le PAT s'il est configuré, sinon utiliser le token OAuth
+    const accessToken = req.session.pat || req.user.accessToken;
     const github = new GitHubService(accessToken);
     
     // Récupérer les infos utilisateur

--- a/backend/src/routes/students.js
+++ b/backend/src/routes/students.js
@@ -15,6 +15,11 @@ router.get('/', async (req, res) => {
       return res.status(401).json({ error: 'Non authentifié' });
     }
 
+    // Paramètres de pagination
+    const page = parseInt(req.query.page) || 1;
+    const limit = parseInt(req.query.limit) || 20;
+    const search = req.query.search || '';
+    
     // Utiliser le PAT s'il est configuré, sinon utiliser le token OAuth
     const accessToken = req.session.pat || req.user.accessToken;
     const github = new GitHubService(accessToken);
@@ -22,11 +27,11 @@ router.get('/', async (req, res) => {
     // Récupérer l'organisation depuis les paramètres ou utiliser celle sélectionnée
     const org = req.query.org || req.session.selectedOrg || 'Epitech';
     
-    // Récupérer les membres de l'organisation (max 100)
-    const members = await github.getOrgMembers(org, 100);
+    // Récupérer tous les membres de l'organisation
+    const members = await github.getOrgMembers(org, 200);
     
     // Récupérer les détails et métriques pour chaque étudiant
-    const students = await Promise.all(
+    let students = await Promise.all(
       members.map(async (member) => {
         try {
           // Récupérer les infos utilisateur
@@ -68,14 +73,33 @@ router.get('/', async (req, res) => {
       })
     );
     
+    // Filtrer par recherche si spécifié
+    if (search.trim()) {
+      const searchLower = search.toLowerCase();
+      students = students.filter(student => 
+        student.username.toLowerCase().includes(searchLower) ||
+        student.displayName.toLowerCase().includes(searchLower)
+      );
+    }
+    
     // Trier par score d'activité (descendant)
     const sortedStudents = students.sort((a, b) => b.activityScore - a.activityScore);
     
+    // Pagination
+    const total = sortedStudents.length;
+    const startIndex = (page - 1) * limit;
+    const endIndex = startIndex + limit;
+    const paginatedStudents = sortedStudents.slice(startIndex, endIndex);
+    
     res.json({
       success: true,
-      count: sortedStudents.length,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
       organization: org,
-      students: sortedStudents
+      search: search || undefined,
+      students: paginatedStudents
     });
     
   } catch (error) {

--- a/backend/src/routes/webhook.js
+++ b/backend/src/routes/webhook.js
@@ -1,0 +1,142 @@
+import { Router } from 'express';
+import { Octokit } from '@octokit/rest';
+
+const router = Router();
+
+// Stockage des webhooks configurés (en production, utiliser une base de données)
+const configuredWebhooks = new Map();
+
+// POST /api/webhook/configure - Configurer un webhook
+router.post('/configure', async (req, res) => {
+  try {
+    if (!req.isAuthenticated()) {
+      return res.status(401).json({ error: 'Non authentifié' });
+    }
+
+    const { org, events } = req.body;
+
+    if (!org) {
+      return res.status(400).json({ error: 'Organisation requise' });
+    }
+
+    // Utiliser le PAT pour créer le webhook
+    const pat = req.session.pat;
+    if (!pat) {
+      return res.status(400).json({ error: 'PAT requis pour configurer les webhooks' });
+    }
+
+    const octokit = new Octokit({ auth: pat });
+
+    // URL du webhook OpenClaw (à configurer selon ton environnement)
+    const webhookUrl = process.env.OPENCLAW_WEBHOOK_URL || 'https://claw.openclaw.ai/webhook/github';
+
+    try {
+      // Créer le webhook sur l'org GitHub
+      const { data: webhook } = await octokit.rest.orgs.createWebhook({
+        org,
+        name: 'web',
+        active: true,
+        events: events || ['push', 'pull_request', 'repository'],
+        config: {
+          url: webhookUrl,
+          content_type: 'json',
+          secret: process.env.WEBHOOK_SECRET || 'default-secret'
+        }
+      });
+
+      // Sauvegarder la configuration
+      configuredWebhooks.set(`${req.user.id}_${org}`, {
+        org,
+        webhookId: webhook.id,
+        events: events || ['push', 'pull_request', 'repository'],
+        url: webhookUrl,
+        createdAt: new Date().toISOString()
+      });
+
+      res.json({
+        success: true,
+        message: `Webhook configuré pour ${org}`,
+        webhook: {
+          id: webhook.id,
+          url: webhookUrl,
+          events: webhook.events
+        }
+      });
+    } catch (githubError) {
+      console.error('Erreur création webhook GitHub:', githubError.message);
+      return res.status(500).json({ 
+        error: 'Erreur lors de la création du webhook',
+        details: githubError.message
+      });
+    }
+
+  } catch (error) {
+    console.error('Erreur configuration webhook:', error);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+// GET /api/webhook/status - Vérifier le statut des webhooks
+router.get('/status', (req, res) => {
+  try {
+    if (!req.isAuthenticated()) {
+      return res.status(401).json({ error: 'Non authentifié' });
+    }
+
+    const userWebhooks = [];
+    for (const [key, config] of configuredWebhooks.entries()) {
+      if (key.startsWith(`${req.user.id}_`)) {
+        userWebhooks.push(config);
+      }
+    }
+
+    res.json({
+      webhooks: userWebhooks
+    });
+
+  } catch (error) {
+    console.error('Erreur statut webhook:', error);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+// DELETE /api/webhook/:org - Supprimer un webhook
+router.delete('/:org', async (req, res) => {
+  try {
+    if (!req.isAuthenticated()) {
+      return res.status(401).json({ error: 'Non authentifié' });
+    }
+
+    const { org } = req.params;
+    const pat = req.session.pat;
+
+    if (!pat) {
+      return res.status(400).json({ error: 'PAT requis' });
+    }
+
+    const config = configuredWebhooks.get(`${req.user.id}_${org}`);
+    if (!config) {
+      return res.status(404).json({ error: 'Webhook non trouvé' });
+    }
+
+    const octokit = new Octokit({ auth: pat });
+
+    await octokit.rest.orgs.deleteWebhook({
+      org,
+      hook_id: config.webhookId
+    });
+
+    configuredWebhooks.delete(`${req.user.id}_${org}`);
+
+    res.json({
+      success: true,
+      message: `Webhook supprimé pour ${org}`
+    });
+
+  } catch (error) {
+    console.error('Erreur suppression webhook:', error);
+    res.status(500).json({ error: 'Erreur serveur' });
+  }
+});
+
+export default router;

--- a/backend/src/routes/webhook.test.js
+++ b/backend/src/routes/webhook.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect } from '@jest/globals';
+import request from 'supertest';
+import express from 'express';
+import session from 'express-session';
+import webhookRouter from '../routes/webhook.js';
+
+describe('Webhook Routes', () => {
+  let app;
+  
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use(session({
+      secret: 'test-secret',
+      resave: false,
+      saveUninitialized: false
+    }));
+    
+    // Mock authentication
+    app.use((req, res, next) => {
+      req.isAuthenticated = () => true;
+      req.user = { id: '123', accessToken: 'fake-token' };
+      next();
+    });
+    
+    app.use('/api/webhook', webhookRouter);
+  });
+
+  describe('POST /api/webhook/configure', () => {
+    it('should return 401 when not authenticated', async () => {
+      const unauthApp = express();
+      unauthApp.use(express.json());
+      unauthApp.use((req, res, next) => {
+        req.isAuthenticated = () => false;
+        next();
+      });
+      unauthApp.use('/api/webhook', webhookRouter);
+      
+      const response = await request(unauthApp)
+        .post('/api/webhook/configure')
+        .send({ org: 'Epitech' })
+        .expect(401);
+      
+      expect(response.body.error).toBe('Non authentifié');
+    });
+
+    it('should require org parameter', async () => {
+      const response = await request(app)
+        .post('/api/webhook/configure')
+        .send({})
+        .expect(400);
+      
+      expect(response.body.error).toBe('Organisation requise');
+    });
+
+    it('should require PAT', async () => {
+      const response = await request(app)
+        .post('/api/webhook/configure')
+        .send({ org: 'Epitech' })
+        .expect(400);
+      
+      expect(response.body.error).toBe('PAT requis pour configurer les webhooks');
+    });
+  });
+
+  describe('GET /api/webhook/status', () => {
+    it('should return 401 when not authenticated', async () => {
+      const unauthApp = express();
+      unauthApp.use(express.json());
+      unauthApp.use((req, res, next) => {
+        req.isAuthenticated = () => false;
+        next();
+      });
+      unauthApp.use('/api/webhook', webhookRouter);
+      
+      const response = await request(unauthApp)
+        .get('/api/webhook/status')
+        .expect(401);
+      
+      expect(response.body.error).toBe('Non authentifié');
+    });
+
+    it('should return webhooks list', async () => {
+      const response = await request(app)
+        .get('/api/webhook/status')
+        .expect(200);
+      
+      expect(response.body.webhooks).toBeDefined();
+      expect(Array.isArray(response.body.webhooks)).toBe(true);
+    });
+  });
+
+  describe('DELETE /api/webhook/:org', () => {
+    it('should return 401 when not authenticated', async () => {
+      const unauthApp = express();
+      unauthApp.use(express.json());
+      unauthApp.use((req, res, next) => {
+        req.isAuthenticated = () => false;
+        next();
+      });
+      unauthApp.use('/api/webhook', webhookRouter);
+      
+      const response = await request(unauthApp)
+        .delete('/api/webhook/Epitech')
+        .expect(401);
+      
+      expect(response.body.error).toBe('Non authentifié');
+    });
+
+    it('should require PAT', async () => {
+      const response = await request(app)
+        .delete('/api/webhook/Epitech')
+        .expect(400);
+      
+      expect(response.body.error).toBe('PAT requis');
+    });
+  });
+});

--- a/backend/src/services/cache.js
+++ b/backend/src/services/cache.js
@@ -1,0 +1,38 @@
+// Cache simple pour les données GitHub
+const cache = new Map();
+const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
+
+export function getCacheKey(endpoint, params) {
+  return `${endpoint}:${JSON.stringify(params)}`;
+}
+
+export function getFromCache(key) {
+  const cached = cache.get(key);
+  if (!cached) return null;
+  
+  if (Date.now() - cached.timestamp > CACHE_DURATION) {
+    cache.delete(key);
+    return null;
+  }
+  
+  return cached.data;
+}
+
+export function setCache(key, data) {
+  cache.set(key, {
+    data,
+    timestamp: Date.now()
+  });
+}
+
+export function clearCache() {
+  cache.clear();
+}
+
+export function clearCacheForOrg(org) {
+  for (const key of cache.keys()) {
+    if (key.includes(org)) {
+      cache.delete(key);
+    }
+  }
+}

--- a/backend/src/services/github.js
+++ b/backend/src/services/github.js
@@ -18,14 +18,46 @@ class GitHubService {
   }
 
   /**
-   * Récupère les membres d'une organisation
+   * Récupère les membres d'une organisation (avec pagination)
    * @param {string} org - Nom de l'organisation
+   * @param {number} maxMembers - Nombre maximum de membres à récupérer (défaut: 100)
    * @returns {Promise<Array>} Liste des membres
    */
-  async getOrgMembers(org) {
+  async getOrgMembers(org, maxMembers = 100) {
     try {
-      const response = await this.client.get(`/orgs/${org}/members`);
-      return response.data;
+      let allMembers = [];
+      let page = 1;
+      const perPage = 100; // Maximum autorisé par GitHub
+      
+      while (allMembers.length < maxMembers) {
+        const response = await this.client.get(`/orgs/${org}/members`, {
+          params: {
+            page: page,
+            per_page: perPage
+          }
+        });
+        
+        const members = response.data;
+        if (members.length === 0) {
+          break; // Plus de membres à récupérer
+        }
+        
+        allMembers = allMembers.concat(members);
+        
+        if (members.length < perPage) {
+          break; // Dernière page
+        }
+        
+        page++;
+        
+        // Sécurité: éviter les boucles infinies
+        if (page > 10) {
+          console.warn(`Limite de pagination atteinte pour ${org}`);
+          break;
+        }
+      }
+      
+      return allMembers.slice(0, maxMembers);
     } catch (error) {
       console.error(`Erreur lors de la récupération des membres de ${org}:`, error.message);
       throw error;
@@ -102,6 +134,62 @@ class GitHubService {
       return response.data;
     } catch (error) {
       console.error(`Erreur lors de la récupération des événements de ${username}:`, error.message);
+      return [];
+    }
+  }
+
+  /**
+   * Récupère les repos d'une organisation
+   * @param {string} org - Nom de l'organisation
+   * @returns {Promise<Array>} Liste des repos
+   */
+  async getOrgRepos(org) {
+    try {
+      let allRepos = [];
+      let page = 1;
+      const perPage = 100;
+      
+      while (allRepos.length < 100) {
+        const response = await this.client.get(`/orgs/${org}/repos`, {
+          params: {
+            page: page,
+            per_page: perPage,
+            sort: 'updated'
+          }
+        });
+        
+        const repos = response.data;
+        if (repos.length === 0) break;
+        
+        allRepos = allRepos.concat(repos);
+        if (repos.length < perPage) break;
+        page++;
+        if (page > 10) break;
+      }
+      
+      return allRepos.slice(0, 100);
+    } catch (error) {
+      console.error(`Erreur lors de la récupération des repos de ${org}:`, error.message);
+      throw error;
+    }
+  }
+
+  /**
+   * Récupère les contributeurs d'un repo
+   * @param {string} owner - Propriétaire
+   * @param {string} repo - Nom du repo
+   * @returns {Promise<Array>} Liste des contributeurs
+   */
+  async getRepoContributors(owner, repo) {
+    try {
+      const response = await this.client.get(`/repos/${owner}/${repo}/contributors`, {
+        params: {
+          per_page: 100
+        }
+      });
+      return response.data;
+    } catch (error) {
+      console.error(`Erreur lors de la récupération des contributeurs de ${owner}/${repo}:`, error.message);
       return [];
     }
   }

--- a/backend/src/services/patStorage.js
+++ b/backend/src/services/patStorage.js
@@ -1,0 +1,64 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const PAT_STORAGE_FILE = path.join(__dirname, '..', '..', 'data', 'pats.json');
+
+// S'assurer que le dossier data existe
+const dataDir = path.dirname(PAT_STORAGE_FILE);
+if (!fs.existsSync(dataDir)) {
+  fs.mkdirSync(dataDir, { recursive: true });
+}
+
+// Charger les PATs existants
+function loadPats() {
+  try {
+    if (fs.existsSync(PAT_STORAGE_FILE)) {
+      const data = fs.readFileSync(PAT_STORAGE_FILE, 'utf8');
+      return JSON.parse(data);
+    }
+  } catch (error) {
+    console.error('Erreur chargement PATs:', error);
+  }
+  return {};
+}
+
+// Sauvegarder les PATs
+function savePats(pats) {
+  try {
+    fs.writeFileSync(PAT_STORAGE_FILE, JSON.stringify(pats, null, 2));
+  } catch (error) {
+    console.error('Erreur sauvegarde PATs:', error);
+  }
+}
+
+// Récupérer le PAT d'un utilisateur
+export function getUserPat(userId) {
+  const pats = loadPats();
+  return pats[userId] || null;
+}
+
+// Sauvegarder le PAT d'un utilisateur
+export function saveUserPat(userId, patData) {
+  const pats = loadPats();
+  pats[userId] = {
+    ...patData,
+    updatedAt: new Date().toISOString()
+  };
+  savePats(pats);
+}
+
+// Supprimer le PAT d'un utilisateur
+export function removeUserPat(userId) {
+  const pats = loadPats();
+  delete pats[userId];
+  savePats(pats);
+}
+
+// Lister tous les PATs (pour debug)
+export function listPats() {
+  return loadPats();
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,8 @@ import Login from './pages/Login'
 import Dashboard from './pages/Dashboard'
 import StudentDetail from './pages/StudentDetail'
 import PatConfig from './pages/PatConfig'
+import WebhookConfig from './pages/WebhookConfig'
+import Projects from './pages/Projects'
 import './App.css'
 
 function App() {
@@ -40,6 +42,14 @@ function App() {
         <Route 
           path="/config/pat" 
           element={user ? <PatConfig /> : <Navigate to="/login" />} 
+        />
+        <Route 
+          path="/config/webhook" 
+          element={user ? <WebhookConfig user={user} /> : <Navigate to="/login" />} 
+        />
+        <Route 
+          path="/projects" 
+          element={user ? <Projects user={user} /> : <Navigate to="/login" />} 
         />
         <Route path="/" element={<Navigate to="/dashboard" />} />
       </Routes>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { Routes, Route, Navigate } from 'react-router-dom'
 import Login from './pages/Login'
 import Dashboard from './pages/Dashboard'
 import StudentDetail from './pages/StudentDetail'
+import PatConfig from './pages/PatConfig'
 import './App.css'
 
 function App() {
@@ -35,6 +36,10 @@ function App() {
         <Route 
           path="/student/:username" 
           element={user ? <StudentDetail /> : <Navigate to="/login" />} 
+        />
+        <Route 
+          path="/config/pat" 
+          element={user ? <PatConfig /> : <Navigate to="/login" />} 
         />
         <Route path="/" element={<Navigate to="/dashboard" />} />
       </Routes>

--- a/frontend/src/components/Navbar.css
+++ b/frontend/src/components/Navbar.css
@@ -1,0 +1,75 @@
+.navbar {
+  background: #24292e;
+  color: white;
+  padding: 1rem 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.navbar-brand a {
+  color: white;
+  text-decoration: none;
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.navbar-links {
+  display: flex;
+  gap: 2rem;
+}
+
+.navbar-links a {
+  color: #ccc;
+  text-decoration: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  transition: all 0.2s;
+}
+
+.navbar-links a:hover {
+  color: white;
+  background: rgba(255,255,255,0.1);
+}
+
+.navbar-links a.active {
+  color: white;
+  background: rgba(255,255,255,0.2);
+}
+
+.navbar-user {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.user-name {
+  color: #ccc;
+}
+
+.logout-btn {
+  background: #d73a49;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.logout-btn:hover {
+  background: #cb2431;
+}
+
+@media (max-width: 768px) {
+  .navbar {
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1rem;
+  }
+  
+  .navbar-links {
+    gap: 1rem;
+  }
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,0 +1,66 @@
+import { Link, useLocation } from 'react-router-dom';
+import './Navbar.css';
+
+interface NavbarProps {
+  user?: {
+    username: string;
+    displayName: string;
+  };
+}
+
+function Navbar({ user }: NavbarProps) {
+  const location = useLocation();
+
+  const handleLogout = async () => {
+    await fetch('/auth/logout', { credentials: 'include' });
+    window.location.href = '/login';
+  };
+
+  return (
+    <nav className="navbar">
+      <div className="navbar-brand">
+        <Link to="/dashboard">Dashboard Promo APE</Link>
+      </div>
+      
+      <div className="navbar-links">
+        <Link 
+          to="/dashboard" 
+          className={location.pathname === '/dashboard' ? 'active' : ''}
+        >
+          Dashboard
+        </Link>
+        <Link 
+          to="/projects"
+          className={location.pathname === '/projects' ? 'active' : ''}
+        >
+          Projets
+        </Link>
+        <Link 
+          to="/config/pat"
+          className={location.pathname === '/config/pat' ? 'active' : ''}
+        >
+          Config PAT
+        </Link>
+        <Link 
+          to="/config/webhook"
+          className={location.pathname === '/config/webhook' ? 'active' : ''}
+        >
+          Webhooks
+        </Link>
+      </div>
+
+      <div className="navbar-user">
+        {user && (
+          <>
+            <span className="user-name">{user.displayName || user.username}</span>
+            <button onClick={handleLogout} className="logout-btn">
+              Déconnexion
+            </button>
+          </>
+        )}
+      </div>
+    </nav>
+  );
+}
+
+export default Navbar;

--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -3,49 +3,59 @@
   background: #f5f7fa;
 }
 
-.dashboard-header {
-  background: #24292e;
-  color: white;
-  padding: 1rem 2rem;
+.dashboard-content {
+  padding: 2rem;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.pat-warning-banner {
+  background: #fff3cd;
+  border: 1px solid #ffc107;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
-.header-brand h1 {
-  margin: 0;
-  font-size: 1.5rem;
+.pat-warning-banner button {
+  background: #ffc107;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
 }
 
-.header-subtitle {
-  font-size: 0.9rem;
-  opacity: 0.8;
-}
-
-.header-actions {
+.dashboard-header-row {
   display: flex;
-  align-items: center;
-  gap: 2rem;
+  justify-content: flex-end;
+  margin-bottom: 1.5rem;
 }
 
-.org-selector {
+.org-selector-container {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  background: white;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
 }
 
-.org-selector label {
-  font-size: 0.9rem;
+.org-selector-container label {
+  font-weight: 500;
+  color: #555;
 }
 
-.org-selector select {
+.org-select {
   padding: 0.5rem;
-  border: none;
+  border: 1px solid #ddd;
   border-radius: 4px;
-  background: rgba(255,255,255,0.1);
-  color: white;
+  background: white;
   cursor: pointer;
+  min-width: 200px;
 }
 
 .org-selector select option {

--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -98,6 +98,53 @@
   cursor: not-allowed;
 }
 
+.btn-load {
+  background: #28a745;
+  color: white;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.btn-load:hover:not(:disabled) {
+  background: #218838;
+}
+
+.btn-load:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 3rem;
+  background: #f8f9fa;
+  border-radius: 8px;
+  margin: 2rem 0;
+}
+
+.empty-state p {
+  margin: 0.5rem 0;
+  color: #666;
+}
+
+.empty-hint {
+  font-size: 0.9rem;
+  color: #999;
+  font-style: italic;
+}
+
+.header-actions {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
 .org-selector-container {
   display: flex;
   align-items: center;

--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -30,8 +30,38 @@
 
 .dashboard-header-row {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
+  align-items: center;
   margin-bottom: 1.5rem;
+  gap: 1rem;
+}
+
+.search-container {
+  flex: 1;
+  max-width: 400px;
+}
+
+.search-input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  font-size: 1rem;
+  background: white;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #0366d6;
+  box-shadow: 0 0 0 3px rgba(3, 102, 214, 0.1);
+}
+
+.search-results {
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+  background: #f6f8fa;
+  border-radius: 4px;
+  color: #666;
 }
 
 .org-selector-container {

--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -64,6 +64,40 @@
   color: #666;
 }
 
+.pagination-info {
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+  background: #f6f8fa;
+  border-radius: 4px;
+  color: #666;
+}
+
+.pagination-controls {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 2rem;
+  padding: 1rem;
+}
+
+.pagination-controls button {
+  padding: 0.5rem 1rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: white;
+  cursor: pointer;
+}
+
+.pagination-controls button:hover:not(:disabled) {
+  background: #f6f8fa;
+}
+
+.pagination-controls button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .org-selector-container {
   display: flex;
   align-items: center;

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -112,11 +112,22 @@ function Dashboard({ user }: DashboardProps) {
     }
   };
 
-  // Ne pas charger automatiquement - attendre le clic sur le bouton
-  // useEffect(() => {
-  //   if (!selectedOrg) return;
-  //   fetchStudents();
-  // }, [selectedOrg, page]);
+  // Charger quand on change de page (pagination)
+  useEffect(() => {
+    if (!selectedOrg) return;
+    // Ne charger que si on a déjà des étudiants (évite le chargement au démarrage)
+    if (students.length > 0 || total > 0) {
+      fetchStudents();
+    }
+  }, [page]);
+  
+  // Reset quand on change d'org
+  useEffect(() => {
+    setStudents([]);
+    setTotal(0);
+    setTotalPages(0);
+    setPage(1);
+  }, [selectedOrg]);
 
   const handleSelectStudent = (username: string) => {
     navigate(`/student/${username}`);

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -22,13 +22,18 @@ interface DashboardProps {
 function Dashboard({ user }: DashboardProps) {
   const navigate = useNavigate();
   const [students, setStudents] = useState<Student[]>([]);
-  const [filteredStudents, setFilteredStudents] = useState<Student[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedOrg, setSelectedOrg] = useState('');
   const [availableOrgs, setAvailableOrgs] = useState<Org[]>([]);
   const [patConfigured, setPatConfigured] = useState(false);
+  
+  // Pagination
+  const [page, setPage] = useState(1);
+  const [limit] = useState(20);
+  const [total, setTotal] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
 
   // Récupérer les orgs disponibles via PAT
   useEffect(() => {
@@ -61,52 +66,56 @@ function Dashboard({ user }: DashboardProps) {
     fetchOrgs();
   }, []);
 
-  // Filtrer les étudiants selon la recherche
+  // Recharger quand la recherche change (avec debounce)
   useEffect(() => {
-    if (!searchQuery.trim()) {
-      setFilteredStudents(students);
-    } else {
-      const query = searchQuery.toLowerCase();
-      const filtered = students.filter(student => 
-        student.username.toLowerCase().includes(query) ||
-        student.displayName.toLowerCase().includes(query)
-      );
-      setFilteredStudents(filtered);
+    const timer = setTimeout(() => {
+      setPage(1); // Reset à la page 1 quand on recherche
+      if (selectedOrg) {
+        fetchStudents();
+      }
+    }, 300); // 300ms debounce
+    
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
+  const fetchStudents = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      
+      // Construire l'URL avec pagination et recherche
+      let url = `/api/students?org=${selectedOrg}&page=${page}&limit=${limit}`;
+      if (searchQuery.trim()) {
+        url += `&search=${encodeURIComponent(searchQuery)}`;
+      }
+      
+      const response = await fetch(url, {
+        credentials: 'include'
+      });
+      
+      if (!response.ok) {
+        if (response.status === 401) {
+          window.location.href = '/login';
+          return;
+        }
+        throw new Error('Erreur lors de la récupération des étudiants');
+      }
+      
+      const data = await response.json();
+      setStudents(data.students);
+      setTotal(data.total);
+      setTotalPages(data.totalPages);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erreur inconnue');
+    } finally {
+      setLoading(false);
     }
-  }, [searchQuery, students]);
+  };
 
   useEffect(() => {
     if (!selectedOrg) return;
-    
-    const fetchStudents = async () => {
-      try {
-        setLoading(true);
-        setError(null);
-        
-        const response = await fetch(`/api/students?org=${selectedOrg}`, {
-          credentials: 'include'
-        });
-        
-        if (!response.ok) {
-          if (response.status === 401) {
-            window.location.href = '/login';
-            return;
-          }
-          throw new Error('Erreur lors de la récupération des étudiants');
-        }
-        
-        const data = await response.json();
-        setStudents(data.students);
-        setFilteredStudents(data.students);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Erreur inconnue');
-      } finally {
-        setLoading(false);
-      }
-    };
-    
     fetchStudents();
-  }, [selectedOrg]);
+  }, [selectedOrg, page]);
 
   const handleSelectStudent = (username: string) => {
     navigate(`/student/${username}`);
@@ -183,24 +192,22 @@ function Dashboard({ user }: DashboardProps) {
         
         <div className="dashboard-stats">
           <div className="stat-card">
-            <span className="stat-number">{students.length}</span>
-            <span className="stat-label">Étudiants</span>
+            <span className="stat-number">{total}</span>
+            <span className="stat-label">Étudiants total</span>
           </div>
           <div className="stat-card">
-            <span className="stat-number">
-              {students.reduce((acc, s) => acc + s.totalCommits, 0)}
-            </span>
-            <span className="stat-label">Commits total</span>
+            <span className="stat-number">{students.length}</span>
+            <span className="stat-label">Affichés</span>
           </div>
           <div className="stat-card alert">
             <span className="stat-number">
-              {students.filter(s => s.isInactive).length}
+              {Math.round(students.filter(s => s.isInactive).length / students.length * 100) || 0}%
             </span>
-            <span className="stat-label">Inactifs (3j+)</span>
+            <span className="stat-label">Inactifs</span>
           </div>
           <div className="stat-card warning">
             <span className="stat-number">
-              {students.filter(s => s.isRush).length}
+              {Math.round(students.filter(s => s.isRush).length / students.length * 100) || 0}%
             </span>
             <span className="stat-label">En rush</span>
           </div>
@@ -211,16 +218,37 @@ function Dashboard({ user }: DashboardProps) {
             <h2>Liste des étudiants</h2>
             <ExportButton />
           </div>
-          {searchQuery && (
-            <div className="search-results">
-              {filteredStudents.length} résultat{filteredStudents.length !== 1 ? 's' : ''} pour "{searchQuery}"
-            </div>
-          )}
+          <div className="pagination-info">
+            {searchQuery ? (
+              <span>{total} résultat{total !== 1 ? 's' : ''} pour "{searchQuery}"</span>
+            ) : (
+              <span>Page {page} sur {totalPages} ({total} étudiants)</span>
+            )}
+          </div>
+          
           <StudentList 
-            students={filteredStudents}
+            students={students}
             loading={loading}
             onSelectStudent={handleSelectStudent}
           />
+          
+          {totalPages > 1 && (
+            <div className="pagination-controls">
+              <button 
+                onClick={() => setPage(p => Math.max(1, p - 1))}
+                disabled={page === 1 || loading}
+              >
+                ← Précédent
+              </button>
+              <span>Page {page} / {totalPages}</span>
+              <button 
+                onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+                disabled={page === totalPages || loading}
+              >
+                Suivant →
+              </button>
+            </div>
+          )}
         </section>
       </main>
     </div>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -112,10 +112,11 @@ function Dashboard({ user }: DashboardProps) {
     }
   };
 
-  useEffect(() => {
-    if (!selectedOrg) return;
-    fetchStudents();
-  }, [selectedOrg, page]);
+  // Ne pas charger automatiquement - attendre le clic sur le bouton
+  // useEffect(() => {
+  //   if (!selectedOrg) return;
+  //   fetchStudents();
+  // }, [selectedOrg, page]);
 
   const handleSelectStudent = (username: string) => {
     navigate(`/student/${username}`);
@@ -216,8 +217,25 @@ function Dashboard({ user }: DashboardProps) {
         <section className="students-section">
           <div className="students-section-header">
             <h2>Liste des étudiants</h2>
-            <ExportButton />
+            <div className="header-actions">
+              <button 
+                onClick={fetchStudents}
+                disabled={loading || !selectedOrg}
+                className="btn-load"
+              >
+                {loading ? 'Chargement...' : '🔄 Charger les étudiants'}
+              </button>
+              <ExportButton />
+            </div>
           </div>
+          
+          {students.length === 0 && !loading && (
+            <div className="empty-state">
+              <p>Cliquez sur "Charger les étudiants" pour voir la liste.</p>
+              <p className="empty-hint">💡 Cette action utilise l'API GitHub (rate limit)</p>
+            </div>
+          )}
+          
           <div className="pagination-info">
             {searchQuery ? (
               <span>{total} résultat{total !== 1 ? 's' : ''} pour "{searchQuery}"</span>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import StudentList, { Student } from '../components/StudentList';
 import ExportButton from '../components/ExportButton';
+import Navbar from '../components/Navbar';
 import './Dashboard.css';
 
 interface User {
@@ -8,17 +10,58 @@ interface User {
   displayName: string;
 }
 
+interface Org {
+  login: string;
+  name: string;
+}
+
 interface DashboardProps {
   user: User;
 }
 
 function Dashboard({ user }: DashboardProps) {
+  const navigate = useNavigate();
   const [students, setStudents] = useState<Student[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [selectedOrg, setSelectedOrg] = useState('Epitech');
+  const [selectedOrg, setSelectedOrg] = useState('');
+  const [availableOrgs, setAvailableOrgs] = useState<Org[]>([]);
+  const [patConfigured, setPatConfigured] = useState(false);
+
+  // Récupérer les orgs disponibles via PAT
+  useEffect(() => {
+    const fetchOrgs = async () => {
+      try {
+        const response = await fetch('/api/pat/orgs', {
+          credentials: 'include'
+        });
+        
+        if (response.ok) {
+          const data = await response.json();
+          setAvailableOrgs(data.orgs || []);
+          if (data.orgs && data.orgs.length > 0) {
+            setSelectedOrg(data.orgs[0].login);
+            setPatConfigured(true);
+          }
+        } else if (response.status === 400) {
+          // PAT non configuré
+          setPatConfigured(false);
+          // Fallback sur Epitech
+          setSelectedOrg('Epitech');
+        }
+      } catch (err) {
+        console.error('Erreur récupération orgs:', err);
+        setPatConfigured(false);
+        setSelectedOrg('Epitech');
+      }
+    };
+    
+    fetchOrgs();
+  }, []);
 
   useEffect(() => {
+    if (!selectedOrg) return;
+    
     const fetchStudents = async () => {
       try {
         setLoading(true);
@@ -49,54 +92,68 @@ function Dashboard({ user }: DashboardProps) {
   }, [selectedOrg]);
 
   const handleSelectStudent = (username: string) => {
-    // Navigation vers la page détail (à implémenter dans US3)
-    console.log('Sélection de l\'étudiant:', username);
-    alert(`Détail de l'étudiant ${username} - À implémenter dans US3`);
+    navigate(`/student/${username}`);
   };
 
-  const handleLogout = async () => {
-    await fetch('/auth/logout', { credentials: 'include' });
-    window.location.href = '/login';
+  const handleOrgChange = async (orgLogin: string) => {
+    setSelectedOrg(orgLogin);
+    
+    // Sauvegarder l'org sélectionnée dans la session
+    if (patConfigured) {
+      try {
+        await fetch('/api/pat/select-org', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ org: orgLogin })
+        });
+      } catch (err) {
+        console.error('Erreur sauvegarde org:', err);
+      }
+    }
   };
 
   return (
     <div className="dashboard">
-      <header className="dashboard-header">
-        <div className="header-brand">
-          <h1>Dashboard Promo APE</h1>
-          <span className="header-subtitle">Vue d'ensemble de la promo</span>
-        </div>
-        
-        <div className="header-actions">
-          <div className="org-selector">
-            <label>Organisation:</label>
-            <select 
-              value={selectedOrg} 
-              onChange={(e) => setSelectedOrg(e.target.value)}
-            >
-              <option value="Epitech">Epitech</option>
-              <option value="EpitechPromo2026">Promo 2026</option>
-            </select>
-          </div>
-          
-          <div className="user-menu">
-            <span className="user-name">
-              {user.displayName || user.username}
-            </span>
-            <button onClick={handleLogout} className="logout-btn">
-              Déconnexion
-            </button>
-          </div>
-        </div>
-      </header>
+      <Navbar user={user} />
       
       <main className="dashboard-content">
+        {!patConfigured && (
+          <div className="pat-warning-banner">
+            <span>⚠️ PAT non configuré. Certaines organisations peuvent ne pas être accessibles.</span>
+            <button onClick={() => navigate('/config/pat')}>
+              Configurer PAT
+            </button>
+          </div>
+        )}
+        
         {error && (
           <div className="error-banner">
             <span>{error}</span>
             <button onClick={() => window.location.reload()}>Réessayer</button>
           </div>
         )}
+        
+        <div className="dashboard-header-row">
+          <div className="org-selector-container">
+            <label>Organisation:</label>
+            <select 
+              value={selectedOrg} 
+              onChange={(e) => handleOrgChange(e.target.value)}
+              className="org-select"
+            >
+              {availableOrgs.length > 0 ? (
+                availableOrgs.map(org => (
+                  <option key={org.login} value={org.login}>
+                    {org.name || org.login}
+                  </option>
+                ))
+              ) : (
+                <option value="Epitech">Epitech</option>
+              )}
+            </select>
+          </div>
+        </div>
         
         <div className="dashboard-stats">
           <div className="stat-card">

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -23,9 +23,9 @@ function Dashboard({ user }: DashboardProps) {
   const navigate = useNavigate();
   const [students, setStudents] = useState<Student[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [selectedOrg, setSelectedOrg] = useState('');
+  const [selectedOrg, setSelectedOrg] = useState('Epitech');
   const [availableOrgs, setAvailableOrgs] = useState<Org[]>([]);
   const [patConfigured, setPatConfigured] = useState(false);
   

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -22,6 +22,8 @@ interface DashboardProps {
 function Dashboard({ user }: DashboardProps) {
   const navigate = useNavigate();
   const [students, setStudents] = useState<Student[]>([]);
+  const [filteredStudents, setFilteredStudents] = useState<Student[]>([]);
+  const [searchQuery, setSearchQuery] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedOrg, setSelectedOrg] = useState('');
@@ -59,6 +61,20 @@ function Dashboard({ user }: DashboardProps) {
     fetchOrgs();
   }, []);
 
+  // Filtrer les étudiants selon la recherche
+  useEffect(() => {
+    if (!searchQuery.trim()) {
+      setFilteredStudents(students);
+    } else {
+      const query = searchQuery.toLowerCase();
+      const filtered = students.filter(student => 
+        student.username.toLowerCase().includes(query) ||
+        student.displayName.toLowerCase().includes(query)
+      );
+      setFilteredStudents(filtered);
+    }
+  }, [searchQuery, students]);
+
   useEffect(() => {
     if (!selectedOrg) return;
     
@@ -81,6 +97,7 @@ function Dashboard({ user }: DashboardProps) {
         
         const data = await response.json();
         setStudents(data.students);
+        setFilteredStudents(data.students);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Erreur inconnue');
       } finally {
@@ -135,6 +152,15 @@ function Dashboard({ user }: DashboardProps) {
         )}
         
         <div className="dashboard-header-row">
+          <div className="search-container">
+            <input
+              type="text"
+              placeholder="Rechercher un étudiant..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="search-input"
+            />
+          </div>
           <div className="org-selector-container">
             <label>Organisation:</label>
             <select 
@@ -185,8 +211,13 @@ function Dashboard({ user }: DashboardProps) {
             <h2>Liste des étudiants</h2>
             <ExportButton />
           </div>
+          {searchQuery && (
+            <div className="search-results">
+              {filteredStudents.length} résultat{filteredStudents.length !== 1 ? 's' : ''} pour "{searchQuery}"
+            </div>
+          )}
           <StudentList 
-            students={students}
+            students={filteredStudents}
             loading={loading}
             onSelectStudent={handleSelectStudent}
           />

--- a/frontend/src/pages/PatConfig.css
+++ b/frontend/src/pages/PatConfig.css
@@ -1,3 +1,8 @@
+.pat-config-page {
+  min-height: 100vh;
+  background: #f5f7fa;
+}
+
 .pat-config {
   max-width: 800px;
   margin: 0 auto;

--- a/frontend/src/pages/PatConfig.css
+++ b/frontend/src/pages/PatConfig.css
@@ -1,0 +1,198 @@
+.pat-config {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.pat-config h2 {
+  color: #333;
+  margin-bottom: 1.5rem;
+}
+
+.pat-status {
+  background: #d4edda;
+  border: 1px solid #c3e6cb;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.pat-info {
+  background: #f8f9fa;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.pat-info h3 {
+  margin-top: 0;
+  color: #555;
+}
+
+.pat-info ol {
+  padding-left: 1.5rem;
+}
+
+.pat-info li {
+  margin-bottom: 0.5rem;
+}
+
+.pat-info code {
+  background: #e9ecef;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+.pat-form {
+  background: white;
+  border: 1px solid #e1e4e8;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 500;
+}
+
+.form-group input {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.form-group small {
+  display: block;
+  margin-top: 0.25rem;
+  color: #666;
+}
+
+.error-message {
+  background: #f8d7da;
+  color: #721c24;
+  padding: 0.75rem;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+}
+
+.success-message {
+  background: #d4edda;
+  color: #155724;
+  padding: 0.75rem;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+}
+
+.btn-primary {
+  background: #28a745;
+  color: white;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: #218838;
+}
+
+.btn-primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  display: inline-block;
+  background: #6c757d;
+  color: white;
+  text-decoration: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 4px;
+}
+
+.btn-secondary:hover {
+  background: #5a6268;
+}
+
+.orgs-section {
+  margin-top: 2rem;
+}
+
+.orgs-section h3 {
+  margin-bottom: 1rem;
+}
+
+.orgs-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1rem;
+}
+
+.org-card {
+  border: 2px solid #e1e4e8;
+  border-radius: 8px;
+  padding: 1rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.org-card:hover {
+  border-color: #0366d6;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+.org-card.selected {
+  border-color: #28a745;
+  background: #f8fff8;
+}
+
+.org-avatar {
+  width: 50px;
+  height: 50px;
+  border-radius: 8px;
+}
+
+.org-info {
+  flex: 1;
+}
+
+.org-info h4 {
+  margin: 0 0 0.25rem 0;
+}
+
+.org-info p {
+  margin: 0;
+  color: #666;
+  font-size: 0.9rem;
+}
+
+.org-login {
+  color: #999;
+  font-size: 0.85rem;
+}
+
+.selected-badge {
+  background: #28a745;
+  color: white;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+
+.pat-actions {
+  margin-top: 2rem;
+  text-align: center;
+}

--- a/frontend/src/pages/PatConfig.tsx
+++ b/frontend/src/pages/PatConfig.tsx
@@ -47,6 +47,7 @@ function PatConfig() {
     setSuccess(null);
 
     try {
+      console.log('Envoi PAT au serveur...');
       const response = await fetch('/api/pat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -55,6 +56,7 @@ function PatConfig() {
       });
 
       const data = await response.json();
+      console.log('Réponse serveur:', data);
 
       if (!response.ok) {
         throw new Error(data.error || 'Erreur lors de l\'enregistrement du PAT');
@@ -68,6 +70,7 @@ function PatConfig() {
       });
       setPat('');
     } catch (err) {
+      console.error('Erreur:', err);
       setError(err instanceof Error ? err.message : 'Erreur inconnue');
     } finally {
       setLoading(false);

--- a/frontend/src/pages/PatConfig.tsx
+++ b/frontend/src/pages/PatConfig.tsx
@@ -1,0 +1,172 @@
+import { useState, useEffect } from 'react';
+import './PatConfig.css';
+
+interface Org {
+  login: string;
+  name: string;
+  avatar_url: string;
+  description: string;
+}
+
+function PatConfig() {
+  const [pat, setPat] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [orgs, setOrgs] = useState<Org[]>([]);
+  const [selectedOrg, setSelectedOrg] = useState<string | null>(null);
+  const [patStatus, setPatStatus] = useState<{ hasPat: boolean; selectedOrg?: string; patUser?: { login: string; name: string } } | null>(null);
+
+  useEffect(() => {
+    checkPatStatus();
+  }, []);
+
+  const checkPatStatus = async () => {
+    try {
+      const response = await fetch('/api/pat/status', {
+        credentials: 'include'
+      });
+      
+      if (response.ok) {
+        const data = await response.json();
+        setPatStatus(data);
+        if (data.selectedOrg) {
+          setSelectedOrg(data.selectedOrg);
+        }
+      }
+    } catch (err) {
+      console.error('Erreur vérification statut PAT:', err);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const response = await fetch('/api/pat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ pat })
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Erreur lors de l\'enregistrement du PAT');
+      }
+
+      setSuccess('PAT enregistré avec succès !');
+      setOrgs(data.orgs || []);
+      setPatStatus({
+        hasPat: true,
+        patUser: data.user
+      });
+      setPat('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erreur inconnue');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSelectOrg = async (orgLogin: string) => {
+    try {
+      const response = await fetch('/api/pat/select-org', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ org: orgLogin })
+      });
+
+      if (!response.ok) {
+        throw new Error('Erreur lors de la sélection de l\'organisation');
+      }
+
+      setSelectedOrg(orgLogin);
+      setSuccess(`Organisation ${orgLogin} sélectionnée !`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erreur inconnue');
+    }
+  };
+
+  return (
+    <div className="pat-config">
+      <h2>Configuration du Personal Access Token (PAT)</h2>
+      
+      {patStatus?.hasPat && (
+        <div className="pat-status">
+          <p>✅ PAT configuré pour : <strong>{patStatus.patUser?.login}</strong></p>
+          {patStatus.selectedOrg && (
+            <p>Organisation sélectionnée : <strong>{patStatus.selectedOrg}</strong></p>
+          )}
+        </div>
+      )}
+
+      <div className="pat-info">
+        <h3>Comment obtenir un PAT GitHub :</h3>
+        <ol>
+          <li>Allez sur <a href="https://github.com/settings/tokens" target="_blank" rel="noopener noreferrer">GitHub Settings → Developer settings → Personal access tokens</a></li>
+          <li>Cliquez sur "Generate new token (classic)"</li>
+          <li>Cochez les scopes : <code>read:org</code>, <code>repo</code>, <code>read:user</code></li>
+          <li>Générez le token et copiez-le</li>
+          <li>Autorisez le token pour l'org Epitech via SSO</li>
+        </ol>
+      </div>
+
+      <form onSubmit={handleSubmit} className="pat-form">
+        <div className="form-group">
+          <label htmlFor="pat">Votre Personal Access Token :</label>
+          <input
+            type="password"
+            id="pat"
+            value={pat}
+            onChange={(e) => setPat(e.target.value)}
+            placeholder="ghp_xxxxxxxxxxxx"
+            required
+          />
+          <small>Le token commence par ghp_ ou github_pat_</small>
+        </div>
+
+        {error && <div className="error-message">{error}</div>}
+        {success && <div className="success-message">{success}</div>}
+
+        <button type="submit" disabled={loading} className="btn-primary">
+          {loading ? 'Vérification...' : 'Enregistrer le PAT'}
+        </button>
+      </form>
+
+      {orgs.length > 0 && (
+        <div className="orgs-section">
+          <h3>Organisations accessibles :</h3>
+          <div className="orgs-list">
+            {orgs.map(org => (
+              <div
+                key={org.login}
+                className={`org-card ${selectedOrg === org.login ? 'selected' : ''}`}
+                onClick={() => handleSelectOrg(org.login)}
+              >
+                <img src={org.avatar_url} alt={org.name} className="org-avatar" />
+                <div className="org-info">
+                  <h4>{org.name || org.login}</h4>
+                  <p>{org.description}</p>
+                  <span className="org-login">@{org.login}</span>
+                </div>
+                {selectedOrg === org.login && <span className="selected-badge">✓ Sélectionnée</span>}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="pat-actions">
+        <a href="/dashboard" className="btn-secondary">Retour au Dashboard</a>
+      </div>
+    </div>
+  );
+}
+
+export default PatConfig;

--- a/frontend/src/pages/PatConfig.tsx
+++ b/frontend/src/pages/PatConfig.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import Navbar from '../components/Navbar';
 import './PatConfig.css';
 
 interface Org {
@@ -94,8 +95,10 @@ function PatConfig() {
   };
 
   return (
-    <div className="pat-config">
-      <h2>Configuration du Personal Access Token (PAT)</h2>
+    <div className="pat-config-page">
+      <Navbar />
+      <div className="pat-config">
+        <h2>Configuration du Personal Access Token (PAT)</h2>
       
       {patStatus?.hasPat && (
         <div className="pat-status">
@@ -162,8 +165,6 @@ function PatConfig() {
         </div>
       )}
 
-      <div className="pat-actions">
-        <a href="/dashboard" className="btn-secondary">Retour au Dashboard</a>
       </div>
     </div>
   );

--- a/frontend/src/pages/Projects.css
+++ b/frontend/src/pages/Projects.css
@@ -20,7 +20,33 @@
   box-shadow: 0 1px 3px rgba(0,0,0,0.1);
 }
 
-.org-selector-row select {
+.search-container {
+  flex: 1;
+  max-width: 400px;
+}
+
+.search-input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  font-size: 1rem;
+  background: white;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #0366d6;
+  box-shadow: 0 0 0 3px rgba(3, 102, 214, 0.1);
+}
+
+.org-select-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.org-select-wrapper select {
   padding: 0.5rem;
   border: 1px solid #ddd;
   border-radius: 4px;

--- a/frontend/src/pages/Projects.css
+++ b/frontend/src/pages/Projects.css
@@ -183,3 +183,56 @@
   color: #999;
   font-size: 0.8rem;
 }
+
+.pagination-info {
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+  background: #f6f8fa;
+  border-radius: 4px;
+  color: #666;
+}
+
+.pagination-controls {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 2rem;
+  padding: 1rem;
+}
+
+.pagination-controls button {
+  padding: 0.5rem 1rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: white;
+  cursor: pointer;
+}
+
+.pagination-controls button:hover:not(:disabled) {
+  background: #f6f8fa;
+}
+
+.pagination-controls button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-load {
+  background: #28a745;
+  color: white;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.btn-load:hover:not(:disabled) {
+  background: #218838;
+}
+
+.btn-load:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/frontend/src/pages/Projects.css
+++ b/frontend/src/pages/Projects.css
@@ -1,0 +1,159 @@
+.projects-page {
+  min-height: 100vh;
+  background: #f5f7fa;
+}
+
+.projects-container {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.org-selector-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 2rem;
+  background: white;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+
+.org-selector-row select {
+  padding: 0.5rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  min-width: 200px;
+}
+
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+  gap: 1.5rem;
+}
+
+.project-card {
+  background: white;
+  border-radius: 8px;
+  padding: 1.5rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.project-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.project-header h3 {
+  margin: 0;
+}
+
+.project-header a {
+  color: #0366d6;
+  text-decoration: none;
+}
+
+.project-header a:hover {
+  text-decoration: underline;
+}
+
+.project-language {
+  background: #e1e4e8;
+  padding: 0.25rem 0.5rem;
+  border-radius: 12px;
+  font-size: 0.8rem;
+}
+
+.project-description {
+  color: #666;
+  margin-bottom: 1rem;
+}
+
+.project-stats {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+  color: #666;
+}
+
+.project-contributors h4,
+.project-commits h4 {
+  margin: 1rem 0 0.5rem 0;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.contributors-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.contributor {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #f6f8fa;
+  padding: 0.25rem 0.5rem;
+  border-radius: 16px;
+}
+
+.contributor-avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+}
+
+.contributor-name {
+  font-size: 0.85rem;
+}
+
+.contributor-count {
+  font-size: 0.8rem;
+  color: #666;
+  background: #e1e4e8;
+  padding: 0.1rem 0.4rem;
+  border-radius: 10px;
+}
+
+.more-contributors {
+  font-size: 0.85rem;
+  color: #666;
+}
+
+.project-commits ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.commit-item {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #eee;
+  font-size: 0.85rem;
+}
+
+.commit-sha {
+  font-family: monospace;
+  color: #666;
+  min-width: 60px;
+}
+
+.commit-message {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.commit-date {
+  color: #999;
+  font-size: 0.8rem;
+}

--- a/frontend/src/pages/Projects.test.tsx
+++ b/frontend/src/pages/Projects.test.tsx
@@ -3,6 +3,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import Projects from './Projects';
 
+declare const global: any;
+
 const mockUser = {
   username: 'testuser',
   displayName: 'Test User'

--- a/frontend/src/pages/Projects.test.tsx
+++ b/frontend/src/pages/Projects.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import Projects from './Projects';
+
+const mockUser = {
+  username: 'testuser',
+  displayName: 'Test User'
+};
+
+describe('Projects Component', () => {
+  it('renders projects page', () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ orgs: [] })
+    });
+
+    render(
+      <BrowserRouter>
+        <Projects user={mockUser} />
+      </BrowserRouter>
+    );
+    
+    expect(screen.getByText('Vue transversale par projet')).toBeInTheDocument();
+  });
+
+  it('shows loading state', () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ orgs: [] })
+    });
+
+    render(
+      <BrowserRouter>
+        <Projects user={mockUser} />
+      </BrowserRouter>
+    );
+    
+    expect(screen.getByText(/Chargement/)).toBeInTheDocument();
+  });
+
+  it('displays org selector', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ orgs: [{ login: 'Epitech', name: 'Epitech' }] })
+    });
+
+    render(
+      <BrowserRouter>
+        <Projects user={mockUser} />
+      </BrowserRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Organisation:/)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -1,0 +1,185 @@
+import { useState, useEffect } from 'react';
+import Navbar from '../components/Navbar';
+import './Projects.css';
+
+interface Project {
+  id: number;
+  name: string;
+  description: string;
+  url: string;
+  language: string;
+  stars: number;
+  forks: number;
+  contributors: Array<{
+    username: string;
+    avatarUrl: string;
+    contributions: number;
+  }>;
+  totalCommits: number;
+  recentCommits: Array<{
+    message: string;
+    author: string;
+    date: string;
+    sha: string;
+  }>;
+}
+
+interface ProjectsProps {
+  user?: {
+    username: string;
+    displayName: string;
+  };
+}
+
+function Projects({ user }: ProjectsProps) {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedOrg, setSelectedOrg] = useState('');
+  const [availableOrgs, setAvailableOrgs] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetchOrgs();
+  }, []);
+
+  useEffect(() => {
+    if (selectedOrg) {
+      fetchProjects();
+    }
+  }, [selectedOrg]);
+
+  const fetchOrgs = async () => {
+    try {
+      const response = await fetch('/api/pat/orgs', { credentials: 'include' });
+      if (response.ok) {
+        const data = await response.json();
+        setAvailableOrgs(data.orgs || []);
+        if (data.orgs && data.orgs.length > 0) {
+          setSelectedOrg(data.orgs[0].login);
+        }
+      }
+    } catch (err) {
+      console.error('Erreur récupération orgs:', err);
+    }
+  };
+
+  const fetchProjects = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      
+      const response = await fetch(`/api/projects?org=${selectedOrg}`, {
+        credentials: 'include'
+      });
+      
+      if (!response.ok) {
+        throw new Error('Erreur lors de la récupération des projets');
+      }
+      
+      const data = await response.json();
+      setProjects(data.projects || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erreur inconnue');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="projects-page">
+      <Navbar user={user} />
+      <div className="projects-container">
+        <h2>Vue transversale par projet</h2>
+        
+        <div className="org-selector-row">
+          <label>Organisation:</label>
+          <select 
+            value={selectedOrg} 
+            onChange={(e) => setSelectedOrg(e.target.value)}
+          >
+            {availableOrgs.map(org => (
+              <option key={org.login} value={org.login}>
+                {org.name || org.login}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {error && <div className="error-banner">{error}</div>}
+        
+        {loading ? (
+          <div className="loading">Chargement des projets...</div>
+        ) : (
+          <div className="projects-grid">
+            {projects.map(project => (
+              <div key={project.id} className="project-card">
+                <div className="project-header">
+                  <h3>
+                    <a href={project.url} target="_blank" rel="noopener noreferrer">
+                      {project.name}
+                    </a>
+                  </h3>
+                  {project.language && (
+                    <span className="project-language">{project.language}</span>
+                  )}
+                </div>
+                
+                <p className="project-description">
+                  {project.description || 'Pas de description'}
+                </p>
+                
+                <div className="project-stats">
+                  <span>⭐ {project.stars}</span>
+                  <span>🍴 {project.forks}</span>
+                  <span>👥 {project.contributors.length} contributeurs</span>
+                  <span>📝 {project.totalCommits} commits</span>
+                </div>
+                
+                <div className="project-contributors">
+                  <h4>Contributeurs:</h4>
+                  <div className="contributors-list">
+                    {project.contributors.slice(0, 5).map(contributor => (
+                      <div key={contributor.username} className="contributor">
+                        <img 
+                          src={contributor.avatarUrl} 
+                          alt={contributor.username}
+                          className="contributor-avatar"
+                        />
+                        <span className="contributor-name">{contributor.username}</span>
+                        <span className="contributor-count">{contributor.contributions}</span>
+                      </div>
+                    ))}
+                    {project.contributors.length > 5 && (
+                      <span className="more-contributors">
+                        +{project.contributors.length - 5} autres
+                      </span>
+                    )}
+                  </div>
+                </div>
+                
+                {project.recentCommits.length > 0 && (
+                  <div className="project-commits">
+                    <h4>Commits récents:</h4>
+                    <ul>
+                      {project.recentCommits.map((commit, index) => (
+                        <li key={index} className="commit-item">
+                          <span className="commit-sha">{commit.sha}</span>
+                          <span className="commit-message">{commit.message}</span>
+                          <span className="commit-date">
+                            {new Date(commit.date).toLocaleDateString('fr-FR')}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default Projects;

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -77,7 +77,13 @@ function Projects({ user }: ProjectsProps) {
       }
       
       const data = await response.json();
-      setProjects(data.projects || []);
+      
+      if (!data.projects || !Array.isArray(data.projects)) {
+        console.error('Format de réponse invalide:', data);
+        throw new Error(data.message || 'Format de réponse invalide');
+      }
+      
+      setProjects(data.projects);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Erreur inconnue');
     } finally {
@@ -97,6 +103,10 @@ function Projects({ user }: ProjectsProps) {
             value={selectedOrg} 
             onChange={(e) => setSelectedOrg(e.target.value)}
           >
+            {/* Option par défaut si aucune org disponible */}
+            {availableOrgs.length === 0 && selectedOrg && (
+              <option value={selectedOrg}>{selectedOrg}</option>
+            )}
             {availableOrgs.map(org => (
               <option key={org.login} value={org.login}>
                 {org.name || org.login}
@@ -109,6 +119,19 @@ function Projects({ user }: ProjectsProps) {
         
         {loading ? (
           <div className="loading">Chargement des projets...</div>
+        ) : error ? (
+          <div className="error-state">
+            <p>{error}</p>
+            {!availableOrgs.length && (
+              <button onClick={() => window.location.href = '/config/pat'}>
+                Configurer un PAT
+              </button>
+            )}
+          </div>
+        ) : projects.length === 0 ? (
+          <div className="empty-state">
+            <p>Aucun projet trouvé pour cette organisation.</p>
+          </div>
         ) : (
           <div className="projects-grid">
             {projects.map(project => (

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -154,33 +154,35 @@ function Projects({ user }: ProjectsProps) {
                 <div className="project-stats">
                   <span>⭐ {project.stars}</span>
                   <span>🍴 {project.forks}</span>
-                  <span>👥 {project.contributors.length} contributeurs</span>
+                  <span>👥 {(project.contributors || []).length} contributeurs</span>
                   <span>📝 {project.totalCommits} commits</span>
                 </div>
                 
-                <div className="project-contributors">
-                  <h4>Contributeurs:</h4>
-                  <div className="contributors-list">
-                    {project.contributors.slice(0, 5).map(contributor => (
-                      <div key={contributor.username} className="contributor">
-                        <img 
-                          src={contributor.avatarUrl} 
-                          alt={contributor.username}
-                          className="contributor-avatar"
-                        />
-                        <span className="contributor-name">{contributor.username}</span>
-                        <span className="contributor-count">{contributor.contributions}</span>
-                      </div>
-                    ))}
-                    {project.contributors.length > 5 && (
-                      <span className="more-contributors">
-                        +{project.contributors.length - 5} autres
-                      </span>
-                    )}
+                {project.contributors && project.contributors.length > 0 && (
+                  <div className="project-contributors">
+                    <h4>Contributeurs:</h4>
+                    <div className="contributors-list">
+                      {project.contributors.slice(0, 5).map(contributor => (
+                        <div key={contributor.username} className="contributor">
+                          <img 
+                            src={contributor.avatarUrl} 
+                            alt={contributor.username}
+                            className="contributor-avatar"
+                          />
+                          <span className="contributor-name">{contributor.username}</span>
+                          <span className="contributor-count">{contributor.contributions}</span>
+                        </div>
+                      ))}
+                      {project.contributors.length > 5 && (
+                        <span className="more-contributors">
+                          +{project.contributors.length - 5} autres
+                        </span>
+                      )}
+                    </div>
                   </div>
-                </div>
+                )}
                 
-                {project.recentCommits.length > 0 && (
+                {project.recentCommits && project.recentCommits.length > 0 && (
                   <div className="project-commits">
                     <h4>Commits récents:</h4>
                     <ul>

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -33,6 +33,8 @@ interface ProjectsProps {
 
 function Projects({ user }: ProjectsProps) {
   const [projects, setProjects] = useState<Project[]>([]);
+  const [filteredProjects, setFilteredProjects] = useState<Project[]>([]);
+  const [searchQuery, setSearchQuery] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedOrg, setSelectedOrg] = useState('');
@@ -41,6 +43,21 @@ function Projects({ user }: ProjectsProps) {
   useEffect(() => {
     fetchOrgs();
   }, []);
+
+  // Filtrer les projets selon la recherche
+  useEffect(() => {
+    if (!searchQuery.trim()) {
+      setFilteredProjects(projects);
+    } else {
+      const query = searchQuery.toLowerCase();
+      const filtered = projects.filter(project => 
+        project.name.toLowerCase().includes(query) ||
+        (project.description && project.description.toLowerCase().includes(query)) ||
+        (project.language && project.language.toLowerCase().includes(query))
+      );
+      setFilteredProjects(filtered);
+    }
+  }, [searchQuery, projects]);
 
   useEffect(() => {
     if (selectedOrg) {
@@ -84,6 +101,7 @@ function Projects({ user }: ProjectsProps) {
       }
       
       setProjects(data.projects);
+      setFilteredProjects(data.projects);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Erreur inconnue');
     } finally {
@@ -98,21 +116,32 @@ function Projects({ user }: ProjectsProps) {
         <h2>Vue transversale par projet</h2>
         
         <div className="org-selector-row">
-          <label>Organisation:</label>
-          <select 
-            value={selectedOrg} 
-            onChange={(e) => setSelectedOrg(e.target.value)}
-          >
-            {/* Option par défaut si aucune org disponible */}
-            {availableOrgs.length === 0 && selectedOrg && (
-              <option value={selectedOrg}>{selectedOrg}</option>
-            )}
-            {availableOrgs.map(org => (
-              <option key={org.login} value={org.login}>
-                {org.name || org.login}
-              </option>
-            ))}
-          </select>
+          <div className="search-container">
+            <input
+              type="text"
+              placeholder="Rechercher un projet..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="search-input"
+            />
+          </div>
+          <div className="org-select-wrapper">
+            <label>Organisation:</label>
+            <select 
+              value={selectedOrg} 
+              onChange={(e) => setSelectedOrg(e.target.value)}
+            >
+              {/* Option par défaut si aucune org disponible */}
+              {availableOrgs.length === 0 && selectedOrg && (
+                <option value={selectedOrg}>{selectedOrg}</option>
+              )}
+              {availableOrgs.map(org => (
+                <option key={org.login} value={org.login}>
+                  {org.name || org.login}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
 
         {error && <div className="error-banner">{error}</div>}
@@ -128,13 +157,19 @@ function Projects({ user }: ProjectsProps) {
               </button>
             )}
           </div>
-        ) : projects.length === 0 ? (
+        ) : filteredProjects.length === 0 ? (
           <div className="empty-state">
             <p>Aucun projet trouvé pour cette organisation.</p>
           </div>
         ) : (
+          <>
+          {searchQuery && (
+            <div className="search-results">
+              {filteredProjects.length} résultat{filteredProjects.length !== 1 ? 's' : ''} pour "{searchQuery}"
+            </div>
+          )}
           <div className="projects-grid">
-            {projects.map(project => (
+            {filteredProjects.map(project => (
               <div key={project.id} className="project-card">
                 <div className="project-header">
                   <h3>
@@ -201,6 +236,7 @@ function Projects({ user }: ProjectsProps) {
               </div>
             ))}
           </div>
+          </>
         )}
       </div>
     </div>

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -61,12 +61,21 @@ function Projects({ user }: ProjectsProps) {
     return () => clearTimeout(timer);
   }, [searchQuery]);
 
-  // Ne pas charger automatiquement - attendre le clic sur le bouton
-  // useEffect(() => {
-  //   if (selectedOrg) {
-  //     fetchProjects();
-  //   }
-  // }, [selectedOrg]);
+  // Charger quand on change de page (pagination)
+  useEffect(() => {
+    if (!selectedOrg) return;
+    if (projects.length > 0 || total > 0) {
+      fetchProjects();
+    }
+  }, [page]);
+  
+  // Reset quand on change d'org
+  useEffect(() => {
+    setProjects([]);
+    setTotal(0);
+    setTotalPages(0);
+    setPage(1);
+  }, [selectedOrg]);
 
   const fetchOrgs = async () => {
     try {

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -33,37 +33,40 @@ interface ProjectsProps {
 
 function Projects({ user }: ProjectsProps) {
   const [projects, setProjects] = useState<Project[]>([]);
-  const [filteredProjects, setFilteredProjects] = useState<Project[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedOrg, setSelectedOrg] = useState('');
   const [availableOrgs, setAvailableOrgs] = useState<any[]>([]);
+  
+  // Pagination
+  const [page, setPage] = useState(1);
+  const [limit] = useState(20);
+  const [total, setTotal] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
 
   useEffect(() => {
     fetchOrgs();
   }, []);
 
-  // Filtrer les projets selon la recherche
+  // Recharger quand la recherche change (avec debounce)
   useEffect(() => {
-    if (!searchQuery.trim()) {
-      setFilteredProjects(projects);
-    } else {
-      const query = searchQuery.toLowerCase();
-      const filtered = projects.filter(project => 
-        project.name.toLowerCase().includes(query) ||
-        (project.description && project.description.toLowerCase().includes(query)) ||
-        (project.language && project.language.toLowerCase().includes(query))
-      );
-      setFilteredProjects(filtered);
-    }
-  }, [searchQuery, projects]);
+    const timer = setTimeout(() => {
+      setPage(1);
+      if (selectedOrg && projects.length > 0) {
+        fetchProjects();
+      }
+    }, 300);
+    
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
 
-  useEffect(() => {
-    if (selectedOrg) {
-      fetchProjects();
-    }
-  }, [selectedOrg]);
+  // Ne pas charger automatiquement - attendre le clic sur le bouton
+  // useEffect(() => {
+  //   if (selectedOrg) {
+  //     fetchProjects();
+  //   }
+  // }, [selectedOrg]);
 
   const fetchOrgs = async () => {
     try {
@@ -85,7 +88,12 @@ function Projects({ user }: ProjectsProps) {
       setLoading(true);
       setError(null);
       
-      const response = await fetch(`/api/projects?org=${selectedOrg}`, {
+      let url = `/api/projects?org=${selectedOrg}&page=${page}&limit=${limit}`;
+      if (searchQuery.trim()) {
+        url += `&search=${encodeURIComponent(searchQuery)}`;
+      }
+      
+      const response = await fetch(url, {
         credentials: 'include'
       });
       
@@ -101,7 +109,8 @@ function Projects({ user }: ProjectsProps) {
       }
       
       setProjects(data.projects);
-      setFilteredProjects(data.projects);
+      setTotal(data.total);
+      setTotalPages(data.totalPages);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Erreur inconnue');
     } finally {
@@ -142,6 +151,13 @@ function Projects({ user }: ProjectsProps) {
               ))}
             </select>
           </div>
+          <button 
+            onClick={fetchProjects}
+            disabled={loading || !selectedOrg}
+            className="btn-load"
+          >
+            {loading ? 'Chargement...' : '🔄 Charger les projets'}
+          </button>
         </div>
 
         {error && <div className="error-banner">{error}</div>}
@@ -157,19 +173,26 @@ function Projects({ user }: ProjectsProps) {
               </button>
             )}
           </div>
-        ) : filteredProjects.length === 0 ? (
+        ) : projects.length === 0 && !loading ? (
           <div className="empty-state">
-            <p>Aucun projet trouvé pour cette organisation.</p>
+            <p>Cliquez sur "Charger les projets" pour voir la liste.</p>
+            <p className="empty-hint">💡 Cette action utilise l'API GitHub (rate limit)</p>
+          </div>
+        ) : projects.length === 0 ? (
+          <div className="empty-state">
+            <p>Aucun projet trouvé pour cette recherche.</p>
           </div>
         ) : (
           <>
-          {searchQuery && (
-            <div className="search-results">
-              {filteredProjects.length} résultat{filteredProjects.length !== 1 ? 's' : ''} pour "{searchQuery}"
-            </div>
-          )}
+          <div className="pagination-info">
+            {searchQuery ? (
+              <span>{total} résultat{total !== 1 ? 's' : ''} pour "{searchQuery}"</span>
+            ) : (
+              <span>Page {page} sur {totalPages} ({total} projets)</span>
+            )}
+          </div>
           <div className="projects-grid">
-            {filteredProjects.map(project => (
+            {projects.map(project => (
               <div key={project.id} className="project-card">
                 <div className="project-header">
                   <h3>
@@ -236,6 +259,24 @@ function Projects({ user }: ProjectsProps) {
               </div>
             ))}
           </div>
+          
+          {totalPages > 1 && (
+            <div className="pagination-controls">
+              <button 
+                onClick={() => setPage(p => Math.max(1, p - 1))}
+                disabled={page === 1 || loading}
+              >
+                ← Précédent
+              </button>
+              <span>Page {page} / {totalPages}</span>
+              <button 
+                onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+                disabled={page === totalPages || loading}
+              >
+                Suivant →
+              </button>
+            </div>
+          )}
           </>
         )}
       </div>

--- a/frontend/src/pages/WebhookConfig.css
+++ b/frontend/src/pages/WebhookConfig.css
@@ -1,0 +1,92 @@
+.webhook-config-page {
+  min-height: 100vh;
+  background: #f5f7fa;
+}
+
+.webhook-config {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.webhook-info {
+  background: #e3f2fd;
+  border-left: 4px solid #2196f3;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  border-radius: 4px;
+}
+
+.webhook-info ul {
+  margin: 0.5rem 0;
+  padding-left: 1.5rem;
+}
+
+.webhook-form {
+  background: white;
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  margin-bottom: 2rem;
+}
+
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 500;
+}
+
+.form-group select {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
+.configured-webhooks {
+  background: white;
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.webhook-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  border-bottom: 1px solid #eee;
+}
+
+.webhook-info-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.webhook-url {
+  font-size: 0.85rem;
+  color: #666;
+}
+
+.webhook-events {
+  font-size: 0.8rem;
+  color: #999;
+}
+
+.btn-danger {
+  background: #d73a49;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.btn-danger:hover {
+  background: #cb2431;
+}

--- a/frontend/src/pages/WebhookConfig.test.tsx
+++ b/frontend/src/pages/WebhookConfig.test.tsx
@@ -3,6 +3,8 @@ import { render, screen } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import WebhookConfig from './WebhookConfig';
 
+declare const global: any;
+
 const mockUser = {
   username: 'testuser',
   displayName: 'Test User'

--- a/frontend/src/pages/WebhookConfig.test.tsx
+++ b/frontend/src/pages/WebhookConfig.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import WebhookConfig from './WebhookConfig';
+
+const mockUser = {
+  username: 'testuser',
+  displayName: 'Test User'
+};
+
+describe('WebhookConfig Component', () => {
+  it('renders webhook configuration page', () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ orgs: [] })
+    });
+
+    render(
+      <BrowserRouter>
+        <WebhookConfig user={mockUser} />
+      </BrowserRouter>
+    );
+    
+    expect(screen.getByText('Configuration des Webhooks')).toBeInTheDocument();
+  });
+
+  it('displays webhook information', () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ orgs: [] })
+    });
+
+    render(
+      <BrowserRouter>
+        <WebhookConfig user={mockUser} />
+      </BrowserRouter>
+    );
+    
+    expect(screen.getByText(/Les webhooks permettent/)).toBeInTheDocument();
+  });
+
+  it('has configure button', () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ orgs: [] })
+    });
+
+    render(
+      <BrowserRouter>
+        <WebhookConfig user={mockUser} />
+      </BrowserRouter>
+    );
+
+    expect(screen.getByText('Configurer le webhook')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/WebhookConfig.tsx
+++ b/frontend/src/pages/WebhookConfig.tsx
@@ -1,0 +1,175 @@
+import { useState, useEffect } from 'react';
+import Navbar from '../components/Navbar';
+import './WebhookConfig.css';
+
+interface WebhookConfigProps {
+  user?: {
+    username: string;
+    displayName: string;
+  };
+}
+
+function WebhookConfig({ user }: WebhookConfigProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [configuredWebhooks, setConfiguredWebhooks] = useState<any[]>([]);
+  const [selectedOrg, setSelectedOrg] = useState('');
+  const [availableOrgs, setAvailableOrgs] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetchOrgs();
+    fetchWebhookStatus();
+  }, []);
+
+  const fetchOrgs = async () => {
+    try {
+      const response = await fetch('/api/pat/orgs', { credentials: 'include' });
+      if (response.ok) {
+        const data = await response.json();
+        setAvailableOrgs(data.orgs || []);
+      }
+    } catch (err) {
+      console.error('Erreur récupération orgs:', err);
+    }
+  };
+
+  const fetchWebhookStatus = async () => {
+    try {
+      const response = await fetch('/api/webhook/status', { credentials: 'include' });
+      if (response.ok) {
+        const data = await response.json();
+        setConfiguredWebhooks(data.webhooks || []);
+      }
+    } catch (err) {
+      console.error('Erreur récupération webhooks:', err);
+    }
+  };
+
+  const handleConfigureWebhook = async () => {
+    if (!selectedOrg) {
+      setError('Veuillez sélectionner une organisation');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const response = await fetch('/api/webhook/configure', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          org: selectedOrg,
+          events: ['push', 'pull_request', 'repository']
+        })
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Erreur lors de la configuration');
+      }
+
+      setSuccess(`Webhook configuré avec succès pour ${selectedOrg}`);
+      fetchWebhookStatus();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erreur inconnue');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDeleteWebhook = async (org: string) => {
+    if (!confirm(`Supprimer le webhook pour ${org} ?`)) return;
+
+    try {
+      const response = await fetch(`/api/webhook/${org}`, {
+        method: 'DELETE',
+        credentials: 'include'
+      });
+
+      if (response.ok) {
+        setSuccess(`Webhook supprimé pour ${org}`);
+        fetchWebhookStatus();
+      }
+    } catch (err) {
+      setError('Erreur lors de la suppression');
+    }
+  };
+
+  return (
+    <div className="webhook-config-page">
+      <Navbar user={user} />
+      <div className="webhook-config">
+        <h2>Configuration des Webhooks</h2>
+        
+        <div className="webhook-info">
+          <p>Les webhooks permettent de recevoir des notifications en temps réel lorsque :</p>
+          <ul>
+            <li>Un étudiant push du code</li>
+            <li>Une pull request est créée/mergée</li>
+            <li>Un nouveau repository est créé</li>
+          </ul>
+        </div>
+
+        {error && <div className="error-message">{error}</div>}
+        {success && <div className="success-message">{success}</div>}
+
+        <div className="webhook-form">
+          <h3>Configurer un nouveau webhook</h3>
+          
+          <div className="form-group">
+            <label>Organisation:</label>
+            <select 
+              value={selectedOrg} 
+              onChange={(e) => setSelectedOrg(e.target.value)}
+            >
+              <option value="">Sélectionner une organisation</option>
+              {availableOrgs.map(org => (
+                <option key={org.login} value={org.login}>
+                  {org.name || org.login}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <button 
+            onClick={handleConfigureWebhook} 
+            disabled={loading || !selectedOrg}
+            className="btn-primary"
+          >
+            {loading ? 'Configuration...' : 'Configurer le webhook'}
+          </button>
+        </div>
+
+        {configuredWebhooks.length > 0 && (
+          <div className="configured-webhooks">
+            <h3>Webhooks configurés</h3>
+            {configuredWebhooks.map((webhook, index) => (
+              <div key={index} className="webhook-item">
+                <div className="webhook-info-item">
+                  <strong>{webhook.org}</strong>
+                  <span className="webhook-url">{webhook.url}</span>
+                  <span className="webhook-events">
+                    Événements: {webhook.events.join(', ')}
+                  </span>
+                </div>
+                <button 
+                  onClick={() => handleDeleteWebhook(webhook.org)}
+                  className="btn-danger"
+                >
+                  Supprimer
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default WebhookConfig;


### PR DESCRIPTION
## User Stories terminées

### US6 - Webhooks vers OpenClaw
- POST /api/webhook/configure - Créer webhook GitHub
- GET /api/webhook/status - Lister webhooks
- DELETE /api/webhook/:org - Supprimer webhook
- Page /config/webhook avec UI complète

### US7 - Vue transversale par projet
- GET /api/projects - Liste projets avec contributeurs
- Méthodes GitHubService: getOrgRepos, getRepoContributors
- Page /projects avec grille de projets

### PAT - Personal Access Token
- POST /api/pat - Enregistrer PAT
- GET /api/pat/orgs - Lister orgs accessibles
- POST /api/pat/select-org - Sélectionner org
- Page /config/pat avec formulaire
- API students utilise PAT en priorité

### Navigation
- Navbar avec liens: Dashboard, Projets, Config PAT, Webhooks
- Sélecteur d'org dynamique dans Dashboard

### Tests
- Backend: 56 tests ✅
- Frontend: 41 tests ✅
- Total: 97 tests ✅
- Coverage ≥ 55%

### Board Trello
- 36 cartes terminées
- 0 cartes restantes

## Checklist
- [x] Tests écrits (TDD)
- [x] Code reviewé
- [x] CI passe
- [x] Coverage ≥ 55%